### PR TITLE
Fix delay bug after refactor

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -15,8 +15,8 @@ extern "C" {
  * A tick takes 100 ms. Hence the loop should be the delay in ms divided by 100.
  */
 void delay(uint32_t delay_ms) {
-	const uint8_t bluenet_ticks = 100;
-	uint32_t ticks = delay_ms / (bluenet_ticks * MICROAPP_LOOP_FREQUENCY);
+	const uint8_t bluenet_tick_duration_ms = 100;
+	uint32_t ticks = delay_ms / (bluenet_tick_duration_ms * MICROAPP_LOOP_FREQUENCY);
 	for (uint32_t i = 0; i < ticks; i++) {
 		uint8_t *payload = getOutgoingMessagePayload();
 		microapp_delay_cmd_t *delay_cmd = (microapp_delay_cmd_t*)(payload);

--- a/src/main.c
+++ b/src/main.c
@@ -16,10 +16,9 @@ extern "C" {
  */
 void delay(uint32_t delay_ms) {
 	const uint8_t bluenet_ticks = 100;
-	uint32_t ticks = delay_ms / bluenet_ticks;
+	uint32_t ticks = delay_ms / (bluenet_ticks * MICROAPP_LOOP_FREQUENCY);
 	for (uint32_t i = 0; i < ticks; i++) {
 		uint8_t *payload = getOutgoingMessagePayload();
-//		io_buffer_t *buffer = getOutgoingMessageBuffer();
 		microapp_delay_cmd_t *delay_cmd = (microapp_delay_cmd_t*)(payload);
 		delay_cmd->header.cmd = CS_MICROAPP_COMMAND_DELAY;
 		delay_cmd->period = ticks;
@@ -29,7 +28,6 @@ void delay(uint32_t delay_ms) {
 
 void signalSetupEnd() {
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t *buffer = getOutgoingMessageBuffer();
 	microapp_cmd_t *cmd = (microapp_cmd_t*)(payload);
 	cmd->cmd = CS_MICROAPP_COMMAND_SETUP_END;
 	cmd->interruptCmd = CS_MICROAPP_COMMAND_NONE;
@@ -38,7 +36,6 @@ void signalSetupEnd() {
 
 void signalLoopEnd() {
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t *buffer = getOutgoingMessageBuffer();
 	microapp_cmd_t *cmd = (microapp_cmd_t*)(payload);
 	cmd->cmd = CS_MICROAPP_COMMAND_LOOP_END;
 	sendMessage();


### PR DESCRIPTION
The delay function had a bug where the true delay was a factor 10 higher than the delay passed as the argument. The cause of this is that the microapp is not called every bluenet tick. Instead, in the `MicroappController::tickMicroapp()` function (https://github.com/crownstone/bluenet/blob/master/source/src/microapp/cs_MicroappController.cpp#L302) the microapp is only called every `MICROAPP_LOOP_FREQUENCY` ticks (default value for `MICROAPP_LOOP_FREQUENCY` is 10, as defined in the shared `cs_MicroappStructs.h`)

The solution is simple: `delay_ms` argument is divided by `MICROAPP_LOOP_FREQUENCY` in the `delay()` function on the microapp side.