### PR TITLE
Change API for GPIO pins, Crownstone relay and dimmer, fix GPIO interrupt bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ include/microapp_header_symbols.ld
 include/microapp_target_symbols.ld
 __pycache__/
 tags
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include $(TARGET_CONFIG_FILE)
 include config.mk
 -include private.mk
 
-SOURCE_FILES=include/startup.S src/main.c src/microapp.c src/Arduino.c src/Wire.cpp src/Serial.cpp src/ArduinoBLE.cpp src/BleUtils.cpp src/BleDevice.cpp src/Mesh.cpp $(SHARED_PATH)/ipc/cs_IpcRamData.c $(TARGET).c
+SOURCE_FILES=include/startup.S src/main.c src/microapp.c src/Arduino.c src/Wire.cpp src/Serial.cpp src/ArduinoBLE.cpp src/BleUtils.cpp src/BleDevice.cpp src/Mesh.cpp src/CrownstoneDimmer.cpp src/CrownstoneRelay.cpp $(SHARED_PATH)/ipc/cs_IpcRamData.c $(TARGET).c
 
 # First initialize, then create .hex file, then .bin file and file end with info
 all: init $(TARGET).hex $(TARGET).bin $(TARGET).info

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Create a microapp that can be run on top of the bluenet firmware on a Crownstone
 
 # Organization
 
-The files can be found in `include` and `src`. There is an example file in the root directory called `example.c`. The
+The files can be found in `include` and `src`. There are some basic examples in `examples`. The
 results can be found in the `build` directory.
 
 # Targets

--- a/examples/basic.ino
+++ b/examples/basic.ino
@@ -2,6 +2,8 @@
 // An example to show a few functions being implemented.
 //
 
+#include <Arduino.h>
+
 // Show how a counter is incremented
 static int counter = 100;
 
@@ -19,8 +21,6 @@ void blink() {
 		state = !state;
 	}
 }
-
-const uint8_t BUTTON1_INDEX = 4;
 
 //
 // An example of a setup function.
@@ -40,20 +40,22 @@ void setup() {
 	serviceData.appUuid = 0x1234;
 
 	// Set digital port 1 to OUTPUT, so we can write.
-	pinMode(1, OUTPUT);
+	pinMode(LED3_PIN, OUTPUT);
 
 	// Join the i2c bus
 	Wire.begin();
 
 	// Set interrupt handler
-	pinMode(BUTTON1_INDEX, INPUT_PULLUP);
-	int result = attachInterrupt(digitalPinToInterrupt(BUTTON1_INDEX), blink, CHANGE);
+	pinMode(BUTTON2_PIN, INPUT_PULLUP);
+	int result = attachInterrupt(BUTTON2_PIN, blink, CHANGE);
 
 	Serial.write("attachInterrupt returns ");
 	Serial.write(result);
 	Serial.println(" ");
 
 	blink();
+
+	digitalWrite(LED3_PIN, LOW);
 }
 
 void i2c() {
@@ -103,11 +105,9 @@ void loop() {
 		// This is in ms
 		delay(10000);
 
-		// See protocol definition for other options.
-		//digitalWrite(1, 0);
 	}
 	// Show counter.
-	//Serial.println(counter);
+	Serial.println(counter);
 
 	// Let's advertise the counter value in the service data.
 	serviceData.data[0] = counter;

--- a/examples/blinky.ino
+++ b/examples/blinky.ino
@@ -1,22 +1,32 @@
 //
-// Blinking a LED
+// Blinking LEDs
 //
 
-byte state = LOW;
-const uint8_t LED3_INDEX = 0x0b;
+#include <Arduino.h>
 
-//
-// An example of a setup function.
-//
+const uint8_t nrLEDs = 3;
+boolean ledState[nrLEDs] = {LOW};
+const uint8_t ledPins[nrLEDs] = {LED1_PIN, LED2_PIN, LED3_PIN};
+uint8_t counter = 0;
+
 void setup() {
-	// Set LED3 to OUTPUT, so we can write.
-	pinMode(LED3_INDEX, OUTPUT);
+	// Set LEDs to OUTPUT, so we can write.
+	for (int i = 0; i < nrLEDs; i++) {
+		pinMode(ledPins[i], OUTPUT);
+	}
 }
 
-//
-// A dummy loop function.
-//
 void loop() {
-	state = !state;
-	digitalWrite(LED3_INDEX, state);
+
+	// get the index of the led to be toggled this cycle
+	uint8_t ledIndex = counter % nrLEDs;
+
+	// toggle the led state of the given led
+	ledState[ledIndex] = ! ledState[ledIndex];
+
+	// write the new led state
+	digitalWrite(ledPins[ledIndex], ledState[ledIndex]);
+
+	// increment the loop counter
+	counter++;
 }

--- a/examples/blinky.ino
+++ b/examples/blinky.ino
@@ -22,7 +22,7 @@ void loop() {
 	uint8_t ledIndex = counter % nrLEDs;
 
 	// toggle the led state of the given led
-	ledState[ledIndex] = ! ledState[ledIndex];
+	ledState[ledIndex] = !ledState[ledIndex];
 
 	// write the new led state
 	digitalWrite(ledPins[ledIndex], ledState[ledIndex]);

--- a/examples/blinky.ino
+++ b/examples/blinky.ino
@@ -1,0 +1,22 @@
+//
+// Blinking a LED
+//
+
+byte state = LOW;
+const uint8_t LED3_INDEX = 0x0b;
+
+//
+// An example of a setup function.
+//
+void setup() {
+	// Set LED3 to OUTPUT, so we can write.
+	pinMode(LED3_INDEX, OUTPUT);
+}
+
+//
+// A dummy loop function.
+//
+void loop() {
+	state = !state;
+	digitalWrite(LED3_INDEX, state);
+}

--- a/examples/button_controlled_led.ino
+++ b/examples/button_controlled_led.ino
@@ -1,0 +1,34 @@
+#include <Arduino.h>
+
+boolean state = LOW;
+
+void blink() {
+	Serial.println("blink");
+
+	// Toggle LED
+	state = !state;
+	digitalWrite(LED1_PIN, state);
+}
+
+void setup() {
+
+	// We can "start" serial.
+	Serial.begin();
+
+	// We can use if(Serial), although this will always return true now (might be different in release mode).
+	if (!Serial) return;
+
+	// Configure LED pin as output
+	pinMode(LED1_PIN, OUTPUT);
+
+	// Set interrupt handler
+	pinMode(BUTTON2_PIN, INPUT_PULLUP);
+	int result = attachInterrupt(BUTTON2_PIN, blink, RISING);
+
+	Serial.print("attachInterrupt returns ");
+	Serial.println(result);
+}
+
+void loop() {
+
+}

--- a/examples/dimming.ino
+++ b/examples/dimming.ino
@@ -1,0 +1,27 @@
+//
+// Dimmer demo
+//
+
+#include <Arduino.h>
+#include <CrownstoneDimmer.h>
+
+CrownstoneDimmer dimmer;
+uint8_t intensity = 0;
+
+void setup() {
+	// Initialize the dimmer
+	dimmer.init();
+}
+
+void loop() {
+	// Write new dimmer value
+	dimmer.setIntensity(intensity);
+
+	// Increment the loop counter until 100 percent
+	if (intensity >= 100) {
+		intensity = 0;
+	}
+	else {
+		intensity = intensity + 10;
+	}
+}

--- a/examples/relay.ino
+++ b/examples/relay.ino
@@ -1,0 +1,29 @@
+//
+// Relay demo
+//
+
+#include <Arduino.h>
+#include <CrownstoneRelay.h>
+
+CrownstoneRelay relay;
+bool relayState = HIGH;
+uint8_t counter = 0;
+
+void setup() {
+	// Initialize the relay
+	relay.init();
+}
+
+void loop() {
+	if (counter++ % 10 != 0) {
+		return;
+	}
+	// Toggle the relay
+	if (relayState) {
+		relay.switchOff();
+	}
+	else {
+		relay.switchOn();
+	}
+	relayState = !relayState;
+}

--- a/include/Arduino.h
+++ b/include/Arduino.h
@@ -89,12 +89,6 @@ void analogWrite(uint8_t pin, int val);
 //
 int attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
 
-//
-// Mapping from digital pins to interrupts. This will be just the same for Crownstone hardware. Any mapping will be
-// done in bluenet.
-//
-// uint8_t digitalPinToInterrupt(uint8_t pin);
-
 typedef bool boolean;
 typedef uint8_t byte;
 

--- a/include/Arduino.h
+++ b/include/Arduino.h
@@ -11,6 +11,31 @@ extern "C" {
 #include <stdint.h>
 
 //
+// Redefinitions for easy pin access. These do NOT correspond to physical pins on a specific board.
+// A maximum of 10 GPIO pins (0-9), 4 button pins (1-4) and 4 LED pins (1-4) are supported.
+// However, keep in mind that for a specific board some of these pins may not exist.
+// The physical pin mapping for your board is defined in bluenet/source/include/boards/{board}.h
+//
+const uint8_t GPIO0_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO0;
+const uint8_t GPIO1_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO1;
+const uint8_t GPIO2_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO2;
+const uint8_t GPIO3_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO3;
+const uint8_t GPIO4_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO4;
+const uint8_t GPIO5_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO5;
+const uint8_t GPIO6_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO6;
+const uint8_t GPIO7_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO7;
+const uint8_t GPIO8_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO8;
+const uint8_t GPIO9_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_GPIO9;
+const uint8_t BUTTON1_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_BUTTON1;
+const uint8_t BUTTON2_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_BUTTON2;
+const uint8_t BUTTON3_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_BUTTON3;
+const uint8_t BUTTON4_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_BUTTON4;
+const uint8_t LED1_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_LED1;
+const uint8_t LED2_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_LED2;
+const uint8_t LED3_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_LED3;
+const uint8_t LED4_PIN = CommandMicroappPin::CS_MICROAPP_COMMAND_PIN_LED4;
+
+//
 // You have to implement the setup() function. It can be empty if there is nothing to do at startup.
 //
 void setup();
@@ -68,7 +93,7 @@ int attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
 // Mapping from digital pins to interrupts. This will be just the same for Crownstone hardware. Any mapping will be
 // done in bluenet.
 //
-uint8_t digitalPinToInterrupt(uint8_t pin);
+// uint8_t digitalPinToInterrupt(uint8_t pin);
 
 typedef bool boolean;
 typedef uint8_t byte;

--- a/include/CrownstoneDimmer.h
+++ b/include/CrownstoneDimmer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Arduino.h>
+
+class CrownstoneDimmer {
+
+private:
+
+	bool _initialized = false;
+
+public:
+
+	void init();
+
+	void setIntensity(uint8_t intensity);
+
+};

--- a/include/CrownstoneRelay.h
+++ b/include/CrownstoneRelay.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Arduino.h>
+
+class CrownstoneRelay {
+
+private:
+
+	bool _initialized = false;
+
+	void setSwitch(CommandMicroappSwitchValue val);
+
+public:
+
+	void init();
+
+	void switchOff();
+
+	void switchOn();
+
+	void switchToggle();
+
+};

--- a/include/microapp.h
+++ b/include/microapp.h
@@ -56,8 +56,8 @@ typedef microapp_ble_device_t ble_dev_t;
 const uint8_t LOW = 0;
 const uint8_t HIGH = !LOW;
 
-// 1 virtual pin, 4 GPIO pins, 4 buttons, and 4 leds
-#define NUMBER_OF_PINS 13
+// 10 GPIO pins, 4 buttons, and 4 leds
+#define NUMBER_OF_PINS 18
 
 // define size_t as a 16-bit unsigned int
 typedef uint16_t size_t;
@@ -118,9 +118,9 @@ uint8_t *getIncomingMessagePayload();
 int sendMessage();
 
 /**
- * Register a softInterrupt locally so that when a message.
+ * Register a softInterrupt locally.
  */
-void registerSoftInterrupt(soft_interrupt_t *interrupt);
+int registerSoftInterrupt(soft_interrupt_t *interrupt);
 
 /**
  * Evoke a previously registered softInterrupt.

--- a/src/Arduino.c
+++ b/src/Arduino.c
@@ -1,8 +1,6 @@
 #include <Arduino.h>
 #include <microapp.h>
 
-#include <Serial.h>
-
 #include <ipc/cs_IpcRamData.h>
 
 bool pinExists(uint8_t pin) {
@@ -67,8 +65,9 @@ int attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode) {
 	interrupt.id = pin;
 	interrupt.softInterruptFunc = reinterpret_cast<softInterruptFunction>(isr);
 	int result = registerSoftInterrupt(&interrupt);
-	Serial.print("registerSoftInterrupt res: ");
-	Serial.println(result);
+	if (result < 0) {
+		return result;
+	}
 
 	uint8_t *payload = getOutgoingMessagePayload();
 	microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(payload);
@@ -95,10 +94,6 @@ void analogReference(uint8_t mode) {
 void analogWrite(uint8_t pin, int val) {
 	digitalWrite(pin, val);
 }
-
-// uint8_t digitalPinToInterrupt(uint8_t pin) {
-// 	return pin + 1;
-// }
 
 void init() {
 }

--- a/src/CrownstoneDimmer.cpp
+++ b/src/CrownstoneDimmer.cpp
@@ -1,0 +1,20 @@
+#include <CrownstoneDimmer.h>
+#include <Serial.h>
+
+void CrownstoneDimmer::init() {
+	_initialized = true;
+}
+
+void CrownstoneDimmer::setIntensity(uint8_t intensity) {
+	if (!_initialized) {
+		Serial.println("Dimmer not initialized");
+		return;
+	}
+	uint8_t *payload = getOutgoingMessagePayload();
+	microapp_dimmer_switch_cmd_t* dimmer_cmd = reinterpret_cast<microapp_dimmer_switch_cmd_t*>(payload);
+	dimmer_cmd->header.cmd = CS_MICROAPP_COMMAND_SWITCH_DIMMER;
+	dimmer_cmd->opcode = CS_MICROAPP_COMMAND_DIMMER;
+	dimmer_cmd->value = intensity;
+
+	sendMessage();
+}

--- a/src/CrownstoneRelay.cpp
+++ b/src/CrownstoneRelay.cpp
@@ -1,0 +1,32 @@
+#include <CrownstoneRelay.h>
+#include <Serial.h>
+
+void CrownstoneRelay::init() {
+	_initialized = true;
+}
+
+void CrownstoneRelay::switchOff() {
+	setSwitch(CS_MICROAPP_COMMAND_SWITCH_OFF);
+}
+
+void CrownstoneRelay::switchOn() {
+	setSwitch(CS_MICROAPP_COMMAND_SWITCH_ON);
+}
+
+void CrownstoneRelay::switchToggle() {
+	setSwitch(CS_MICROAPP_COMMAND_SWITCH_TOGGLE);
+}
+
+void CrownstoneRelay::setSwitch(CommandMicroappSwitchValue val) {
+	if (!_initialized) {
+		Serial.println("Relay not initialized");
+		return;
+	}
+	uint8_t *payload = getOutgoingMessagePayload();
+	microapp_dimmer_switch_cmd_t* switch_cmd = reinterpret_cast<microapp_dimmer_switch_cmd_t*>(payload);
+	switch_cmd->header.cmd = CS_MICROAPP_COMMAND_SWITCH_DIMMER;
+	switch_cmd->opcode = CS_MICROAPP_COMMAND_SWITCH;
+	switch_cmd->value = val;
+
+	sendMessage();
+}

--- a/src/main.c
+++ b/src/main.c
@@ -15,8 +15,8 @@ extern "C" {
  * A tick takes 100 ms. Hence the loop should be the delay in ms divided by 100.
  */
 void delay(uint32_t delay_ms) {
-	const uint8_t bluenet_ticks = 100;
-	uint32_t ticks = delay_ms / (bluenet_ticks * MICROAPP_LOOP_FREQUENCY);
+	const uint8_t bluenet_tick_duration_ms = 100;
+	uint32_t ticks = delay_ms / (bluenet_tick_duration_ms * MICROAPP_LOOP_FREQUENCY);
 	for (uint32_t i = 0; i < ticks; i++) {
 		uint8_t *payload = getOutgoingMessagePayload();
 		microapp_delay_cmd_t *delay_cmd = (microapp_delay_cmd_t*)(payload);

--- a/src/main.c
+++ b/src/main.c
@@ -16,10 +16,9 @@ extern "C" {
  */
 void delay(uint32_t delay_ms) {
 	const uint8_t bluenet_ticks = 100;
-	uint32_t ticks = delay_ms / bluenet_ticks;
+	uint32_t ticks = delay_ms / (bluenet_ticks * MICROAPP_LOOP_FREQUENCY);
 	for (uint32_t i = 0; i < ticks; i++) {
 		uint8_t *payload = getOutgoingMessagePayload();
-//		io_buffer_t *buffer = getOutgoingMessageBuffer();
 		microapp_delay_cmd_t *delay_cmd = (microapp_delay_cmd_t*)(payload);
 		delay_cmd->header.cmd = CS_MICROAPP_COMMAND_DELAY;
 		delay_cmd->period = ticks;
@@ -29,7 +28,6 @@ void delay(uint32_t delay_ms) {
 
 void signalSetupEnd() {
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t *buffer = getOutgoingMessageBuffer();
 	microapp_cmd_t *cmd = (microapp_cmd_t*)(payload);
 	cmd->cmd = CS_MICROAPP_COMMAND_SETUP_END;
 	cmd->interruptCmd = CS_MICROAPP_COMMAND_NONE;
@@ -38,7 +36,6 @@ void signalSetupEnd() {
 
 void signalLoopEnd() {
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t *buffer = getOutgoingMessageBuffer();
 	microapp_cmd_t *cmd = (microapp_cmd_t*)(payload);
 	cmd->cmd = CS_MICROAPP_COMMAND_LOOP_END;
 	sendMessage();

--- a/src/microapp.c
+++ b/src/microapp.c
@@ -310,11 +310,7 @@ int handleSoftInterrupt(microapp_cmd_t* msg) {
 			break;
 		}
 		case CS_MICROAPP_COMMAND_PIN: {
-			microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(msg);
-			if (pin_cmd->value != CS_MICROAPP_COMMAND_VALUE_CHANGE) {
-				break;
-			}
-			result = handleSoftInterruptInternal(SOFT_INTERRUPT_TYPE_PIN, pin_cmd->header.id, (uint8_t*)msg);
+			result = handleSoftInterruptInternal(SOFT_INTERRUPT_TYPE_PIN, msg->id, (uint8_t*)msg);
 
 			// After handling the interrupt, yield control back to bluenet
 			uint8_t *payload = getOutgoingMessagePayload();


### PR DESCRIPTION
This PR is paired with a bluenet PR (https://github.com/crownstone/bluenet/pull/158).

## GPIO pin API
In `Arduino.h` a set of GPIO, button and LED virtual pins are redefined from the shared `cs_MicroappStructs.h` which provide a more intuitive access to GPIOs, buttons and LEDs for the user. 

## Crownstone dimmer and relay classes
Dimmer and relay control are moved from the GPIO API to separate classes. The shared protocol for bluenet-microapp communication is updated to reflect this.

## Added examples
The following examples were added:
* `blinky.ino`
* `button_controlled_led.ino`
* `dimmer.ino`
* `relay.ino`

## GPIO interrupt bugfix
For handling interrupts, two bugs were identified. One of these will be solved by a fix in bluenet (see the bluenet PR). The other is fixed in this PR. The current behavior after handling a softInterrupt is to continue execution until the next `sendMessage()`call. However, the intended behavior probably is to yield control back to bluenet directly after handling the interrupt. For the BLE interrupt this was already implemented, but not for the GPIO interrupt. Hence, the call to `sendMessage()` in `handleSoftInterrupt()`.

## Testing
The changes in this PR have been tested with a PCA10040 board. Due to not having microapp-enabled bluenet firmware releases, the dimmer and relay have not been tested on a builtin/plugin. Tests on a dev board with the nrf52840 would be useful to test for bugs.

## Documentation
The README in the `docs` folder has been expanded to include sequence diagrams for calls to the microapp as a result of bluenet ticks (aka regular loop calls) and for interrupt calls.


Feedback appreciated.
