### PR TITLE
Microapp mesh

### DIFF
--- a/examples/basic.ino
+++ b/examples/basic.ino
@@ -49,11 +49,9 @@ void setup() {
 
 	// Set interrupt handler
 	pinMode(BUTTON2_PIN, INPUT_PULLUP);
-	int result = attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, CHANGE);
-
-	Serial.write("attachInterrupt returns ");
-	Serial.write(result);
-	Serial.println(" ");
+	if (!attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, CHANGE)) {
+		Serial.println("Setting button interrupt failed");
+	}
 
 }
 

--- a/examples/basic.ino
+++ b/examples/basic.ino
@@ -40,6 +40,7 @@ void setup() {
 
 	// Set the UUID of this microapp.
 	serviceData.appUuid = 0x1234;
+	serviceData.dlen = 1;
 
 	// Set LED pin to OUTPUT, so we can write.
 	pinMode(LED2_PIN, OUTPUT);

--- a/examples/ble_peripheral_xiaomi_thermometer.ino
+++ b/examples/ble_peripheral_xiaomi_thermometer.ino
@@ -2,7 +2,7 @@
 
 // A ble microapp example for reading advertisements from a Xiaomi Thermometer with custom firmware: https://github.com/atc1441/ATC_MiThermometer
 
-static uint16_t counter = 1;
+uint16_t loopCounter = 0;
 
 bool scanToggle = false;
 
@@ -10,11 +10,10 @@ const char* myAddress = "A4:C1:38:9A:45:E3";
 //const char* myName = "ATC_9A45E3";
 //const char* myUuid = "181A";
 
-// const char* myAddress = "DC:9F:FE:40:F3:1B";
-// const char* myName = "CRWN";
-// const char* myUuid = "181A";
+// For more extensive information about the scanned device
+#define PRINT_EXTENSIVE
+#undef PRINT_EXTENSIVE
 
-// #define PRINT_EXTENSIVE
 // callback for received peripheral advertisement
 void onScannedDevice(BleDevice device) {
 
@@ -67,10 +66,10 @@ void setup() {
 void loop() {
 
 	// Say something every time we loop (which is every second)
-	Serial.println(counter);
+	Serial.println(loopCounter);
 
 	// we would like to loop every 10000 ms (10 seconds)
-	if ((counter >= (10000 / MICROAPP_LOOP_INTERVAL_MS)))
+	if ((loopCounter >= (10000 / MICROAPP_LOOP_INTERVAL_MS)))
 	{
 		scanToggle = !scanToggle;
 		Serial.println("Toggle scanning");
@@ -85,7 +84,7 @@ void loop() {
 		{
 			BLE.stopScan();
 		}
-		counter = 0;
+		loopCounter = 0;
 	}
-	counter++;
+	loopCounter++;
 }

--- a/examples/ble_peripheral_xiaomi_thermometer.ino
+++ b/examples/ble_peripheral_xiaomi_thermometer.ino
@@ -2,22 +2,22 @@
 
 // A ble microapp example for reading advertisements from a Xiaomi Thermometer with custom firmware: https://github.com/atc1441/ATC_MiThermometer
 
-static uint16_t counter = 0;
+static uint16_t counter = 1;
 
-bool scanToggle = true;
+bool scanToggle = false;
 
-//const char* myAddress = "A4:C1:38:9A:45:E3";
+const char* myAddress = "A4:C1:38:9A:45:E3";
 //const char* myName = "ATC_9A45E3";
 //const char* myUuid = "181A";
 
-const char* myAddress = "DC:9F:FE:40:F3:1B";
-const char* myName = "CRWN";
-const char* myUuid = "181A";
+// const char* myAddress = "DC:9F:FE:40:F3:1B";
+// const char* myName = "CRWN";
+// const char* myUuid = "181A";
 
 // callback for received peripheral advertisement
 void my_callback_func(BleDevice device) {
 
-	Serial.println("BLE");
+	Serial.println("BLE device scanned");
 	Serial.print("\trssi: ");
 	Serial.println(device.rssi());
 
@@ -31,7 +31,7 @@ void my_callback_func(BleDevice device) {
 
 	// parse service data of Xiaomi device advertisement if available
 	data_ptr_t serviceData;
-	if (device.findAdvertisementDataType(GapAdvType::ServiceData,&serviceData)) {
+	if (device.findAdvertisementDataType(GapAdvType::ServiceData, &serviceData)) {
 		if (serviceData.len == 15) { // service data length of the Xiaomi service data advertisements
 			Serial.println("\tService data");
 			uint8_t UUID[2] = {serviceData.data[1], serviceData.data[0]};
@@ -44,7 +44,7 @@ void my_callback_func(BleDevice device) {
 			Serial.print("\t\tBattery \%: "); Serial.println(battery_perc);
 		}
 		else {
-			Serial.println("\tIncorrect thermometer service");
+			Serial.println("\tIncorrect thermometer service data length");
 		}
 	}
 }
@@ -65,28 +65,10 @@ void setup() {
 void loop() {
 
 	// Say something every time we loop (which is every second)
-	//Serial.println("Loop");
-
-	// See if we have something available...
-	BleDevice peripheral = BLE.available();
-	// if (peripheral) {
-	// 	Serial.println("loop BLE.available(): ");
-	// 	Serial.print("\trssi: "); Serial.println(peripheral.rssi());
-	// 	Serial.print("\taddress: "); Serial.println(peripheral.address().c_str());
-	// }
-
-	if (peripheral && !peripheral.connected()) {
-		Serial.println("Connecting...");
-		if (peripheral.connect()) {
-			Serial.println("Connected!");
-		}
-		else {
-			Serial.println("Failed to connect!");
-		}
-	}
+	Serial.println(counter);
 
 	// we would like to loop every 10000 ms (10 seconds)
-	if ((counter % (10000 / MICROAPP_LOOP_INTERVAL_MS)) == 0) // every 100 loops, toggle scanning
+	if ((counter >= (10000 / MICROAPP_LOOP_INTERVAL_MS)))
 	{
 		scanToggle = !scanToggle;
 		Serial.println("Toggle");
@@ -101,6 +83,7 @@ void loop() {
 		{
 			BLE.stopScan();
 		}
+		counter = 0;
 	}
 	counter++;
 }

--- a/examples/ble_peripheral_xiaomi_thermometer.ino
+++ b/examples/ble_peripheral_xiaomi_thermometer.ino
@@ -15,7 +15,7 @@ const char* myAddress = "A4:C1:38:9A:45:E3";
 // const char* myUuid = "181A";
 
 // callback for received peripheral advertisement
-void my_callback_func(BleDevice device) {
+void onScannedDevice(BleDevice device) {
 
 	Serial.println("BLE device scanned");
 	Serial.print("\trssi: ");
@@ -58,7 +58,7 @@ void setup() {
 	Serial.println("Setup");
 
 	// Register my_callback_func
-	BLE.setEventHandler(BleEventDeviceScanned, my_callback_func);
+	BLE.setEventHandler(BleEventDeviceScanned, onScannedDevice);
 }
 
 // The Arduino loop function.

--- a/examples/ble_peripheral_xiaomi_thermometer.ino
+++ b/examples/ble_peripheral_xiaomi_thermometer.ino
@@ -14,6 +14,7 @@ const char* myAddress = "A4:C1:38:9A:45:E3";
 // const char* myName = "CRWN";
 // const char* myUuid = "181A";
 
+// #define PRINT_EXTENSIVE
 // callback for received peripheral advertisement
 void onScannedDevice(BleDevice device) {
 
@@ -24,27 +25,28 @@ void onScannedDevice(BleDevice device) {
 	Serial.print("\taddress: ");
 	Serial.println(device.address().c_str());
 
+#ifdef PRINT_EXTENSIVE
 	if (device.hasLocalName()) {
 		Serial.print("\tComplete local name: ");
 		Serial.println(device.localName().c_str());
 	}
+#endif
 
 	// parse service data of Xiaomi device advertisement if available
 	data_ptr_t serviceData;
 	if (device.findAdvertisementDataType(GapAdvType::ServiceData, &serviceData)) {
 		if (serviceData.len == 15) { // service data length of the Xiaomi service data advertisements
-			Serial.println("\tService data");
-			uint8_t UUID[2] = {serviceData.data[1], serviceData.data[0]};
-			Serial.print("\t\tUUID: "); Serial.println(UUID,2);
 			uint16_t temperature = (serviceData.data[8] << 8) | serviceData.data[9];
-			Serial.print("\t\tTemperature: "); Serial.println(temperature);
+			Serial.print("\tTemperature: "); Serial.println(temperature);
+#ifdef PRINT_EXTENSIVE
 			uint8_t humidity = serviceData.data[10];
-			Serial.print("\t\tHumidity: "); Serial.println(humidity);
+			Serial.print("\tHumidity: "); Serial.println(humidity);
 			uint16_t battery_perc = serviceData.data[11];
-			Serial.print("\t\tBattery \%: "); Serial.println(battery_perc);
+			Serial.print("\tBattery \%: "); Serial.println(battery_perc);
+#endif
 		}
 		else {
-			Serial.println("\tIncorrect thermometer service data length");
+			Serial.println("\tIncorrect service data length");
 		}
 	}
 }
@@ -71,7 +73,7 @@ void loop() {
 	if ((counter >= (10000 / MICROAPP_LOOP_INTERVAL_MS)))
 	{
 		scanToggle = !scanToggle;
-		Serial.println("Toggle");
+		Serial.println("Toggle scanning");
 		if (scanToggle)
 		{
 			// BLE.scan(); // unfiltered!

--- a/examples/button_controlled_led.ino
+++ b/examples/button_controlled_led.ino
@@ -18,7 +18,7 @@ void setup() {
 
 	// Set interrupt handler
 	pinMode(BUTTON2_PIN, INPUT_PULLUP);
-	if (attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, RISING) < 0) {
+	if (!attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, RISING)) {
 		Serial.println("Setting button interrupt failed");
 	}
 

--- a/examples/button_controlled_led.ino
+++ b/examples/button_controlled_led.ino
@@ -11,22 +11,17 @@ void blink() {
 }
 
 void setup() {
-
-	// We can "start" serial.
 	Serial.begin();
-
-	// We can use if(Serial), although this will always return true now (might be different in release mode).
-	if (!Serial) return;
 
 	// Configure LED pin as output
 	pinMode(LED1_PIN, OUTPUT);
 
 	// Set interrupt handler
 	pinMode(BUTTON2_PIN, INPUT_PULLUP);
-	int result = attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, RISING);
+	if (attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, RISING) < 0) {
+		Serial.println("Setting button interrupt failed");
+	}
 
-	Serial.print("attachInterrupt returns ");
-	Serial.println(result);
 }
 
 void loop() {

--- a/examples/faulty.ino
+++ b/examples/faulty.ino
@@ -27,8 +27,7 @@ void setup() {
 	while(true) {};
 #endif
 
-	// TODO: the following is now overwritten by setting the interrupt handler
-	//pinMode(BUTTON2_PIN, INPUT_PULLUP);
+	pinMode(BUTTON2_PIN, INPUT_PULLUP);
 	// Set interrupt handler
 	attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), introduceFaultInInterruptHandler, CHANGE);
 }

--- a/examples/interrupts.ino
+++ b/examples/interrupts.ino
@@ -56,10 +56,6 @@ void setup() {
 	}
 #endif
 
-	// This delay causes a yield to bluenet which is needed because
-	// setup() otherwise contains too many consecutive non-yielding microapp calls
-	delay(1500);
-
 #ifdef ENABLE_BLE_INTERRUPTS
 	// initialize ble
 	if (!BLE.setEventHandler(BleEventDeviceScanned, onScannedDevice)) {

--- a/examples/interrupts.ino
+++ b/examples/interrupts.ino
@@ -61,4 +61,5 @@ void setup() {
 }
 
 void loop() {
+
 }

--- a/examples/interrupts.ino
+++ b/examples/interrupts.ino
@@ -72,8 +72,8 @@ void setup() {
 
 #ifdef ENABLE_MESH_INTERRUPTS
 	// initialize mesh
-	MESH.setIncomingMeshMsgHandler(onReceivedMeshMsg);
-	if (!MESH.listen()) {
+	Mesh.setIncomingMeshMsgHandler(onReceivedMeshMsg);
+	if (!Mesh.listen()) {
 		Serial.println("Listening to mesh failed");
 	}
 #endif

--- a/examples/interrupts.ino
+++ b/examples/interrupts.ino
@@ -51,7 +51,7 @@ void setup() {
 
 #ifdef ENABLE_GPIO_INTERRUPTS
 	pinMode(BUTTON1_PIN, INPUT_PULLUP);
-	if (attachInterrupt(digitalPinToInterrupt(BUTTON1_PIN), onPushedButton, RISING) < 0) {
+	if (!attachInterrupt(digitalPinToInterrupt(BUTTON1_PIN), onPushedButton, RISING)) {
 		Serial.println("Setting button interrupt failed");
 	}
 #endif

--- a/examples/interrupts.ino
+++ b/examples/interrupts.ino
@@ -1,0 +1,64 @@
+#include <Arduino.h>
+#include <ArduinoBLE.h>
+#include <Mesh.h>
+#include <Serial.h>
+
+boolean led1state = LOW;
+boolean led2state = LOW;
+boolean led3state = LOW;
+
+const char* bleBeaconAddress = "A4:C1:38:9A:45:E3";
+
+void onScannedDevice(BleDevice device) {
+	// toggle led1
+	Serial.println("Scanned device");
+	led1state = !led1state;
+	digitalWrite(LED1_PIN, led1state);
+}
+
+void onReceivedMeshMsg(MeshMsg msg) {
+	// toggle led2
+	Serial.println("Received mesh message");
+	led2state = !led2state;
+	digitalWrite(LED2_PIN, led2state);
+}
+
+void onPushedButton() {
+	// toggle led3
+	Serial.println("Detected button press");
+	led3state = !led3state;
+	digitalWrite(LED3_PIN, led3state);
+}
+
+void setup() {
+	Serial.begin();
+	Serial.println("Interrupt test code");
+
+	// initialize gpio
+	pinMode(LED1_PIN, OUTPUT);
+	pinMode(LED2_PIN, OUTPUT);
+	pinMode(LED3_PIN, OUTPUT);
+	pinMode(BUTTON1_PIN, INPUT_PULLUP);
+	if (attachInterrupt(digitalPinToInterrupt(BUTTON1_PIN), onPushedButton, RISING) < 0) {
+		Serial.println("Setting button interrupt failed");
+	}
+
+	delay(1500);
+
+	// initialize ble
+	if (!BLE.setEventHandler(BleEventDeviceScanned, onScannedDevice)) {
+		Serial.println("Setting BLE event handler failed");
+	}
+	if (!BLE.scanForAddress(bleBeaconAddress)) {
+		Serial.println("Scanning for BLE address failed");
+	}
+
+	// initialize mesh
+	MESH.setIncomingMeshMsgHandler(onReceivedMeshMsg);
+	if (!MESH.listen()) {
+		Serial.println("Listening to mesh failed");
+	}
+}
+
+void loop() {
+}

--- a/examples/interrupts.ino
+++ b/examples/interrupts.ino
@@ -3,32 +3,42 @@
 #include <Mesh.h>
 #include <Serial.h>
 
+#define ENABLE_BLE_INTERRUPTS
+#define ENABLE_MESH_INTERRUPTS
+#define ENABLE_GPIO_INTERRUPTS
+
 boolean led1state = LOW;
 boolean led2state = LOW;
 boolean led3state = LOW;
 
 const char* bleBeaconAddress = "A4:C1:38:9A:45:E3";
 
+#ifdef ENABLE_BLE_INTERRUPTS
 void onScannedDevice(BleDevice device) {
 	// toggle led1
 	Serial.println("Scanned device");
 	led1state = !led1state;
 	digitalWrite(LED1_PIN, led1state);
 }
+#endif
 
+#ifdef ENABLE_MESH_INTERRUPTS
 void onReceivedMeshMsg(MeshMsg msg) {
 	// toggle led2
 	Serial.println("Received mesh message");
 	led2state = !led2state;
 	digitalWrite(LED2_PIN, led2state);
 }
+#endif
 
+#ifdef ENABLE_GPIO_INTERRUPTS
 void onPushedButton() {
 	// toggle led3
 	Serial.println("Detected button press");
 	led3state = !led3state;
 	digitalWrite(LED3_PIN, led3state);
 }
+#endif
 
 void setup() {
 	Serial.begin();
@@ -38,13 +48,19 @@ void setup() {
 	pinMode(LED1_PIN, OUTPUT);
 	pinMode(LED2_PIN, OUTPUT);
 	pinMode(LED3_PIN, OUTPUT);
+
+#ifdef ENABLE_GPIO_INTERRUPTS
 	pinMode(BUTTON1_PIN, INPUT_PULLUP);
 	if (attachInterrupt(digitalPinToInterrupt(BUTTON1_PIN), onPushedButton, RISING) < 0) {
 		Serial.println("Setting button interrupt failed");
 	}
+#endif
 
+	// This delay causes a yield to bluenet which is needed because
+	// setup() otherwise contains too many consecutive non-yielding microapp calls
 	delay(1500);
 
+#ifdef ENABLE_BLE_INTERRUPTS
 	// initialize ble
 	if (!BLE.setEventHandler(BleEventDeviceScanned, onScannedDevice)) {
 		Serial.println("Setting BLE event handler failed");
@@ -52,12 +68,15 @@ void setup() {
 	if (!BLE.scanForAddress(bleBeaconAddress)) {
 		Serial.println("Scanning for BLE address failed");
 	}
+#endif
 
+#ifdef ENABLE_MESH_INTERRUPTS
 	// initialize mesh
 	MESH.setIncomingMeshMsgHandler(onReceivedMeshMsg);
 	if (!MESH.listen()) {
 		Serial.println("Listening to mesh failed");
 	}
+#endif
 }
 
 void loop() {

--- a/examples/mesh.ino
+++ b/examples/mesh.ino
@@ -1,8 +1,8 @@
 #include <Mesh.h>
 #include <Serial.h>
 
-#define ROLE_RECEIVER
-// #define ROLE_TRANSMITTER
+// #define ROLE_RECEIVER
+#define ROLE_TRANSMITTER
 
 uint32_t counter;
 
@@ -56,7 +56,8 @@ void loop() {
 		// Send Mesh
 		Serial.println("Sending mesh msg");
 		uint8_t msg[2] = {20, 19};
-		uint8_t stoneId = 6;
+		// use 0 as stoneId for broadcast
+		uint8_t stoneId = 0;
 		MESH.sendMeshMsg(msg, sizeof(msg), stoneId);
 	}
 #endif

--- a/examples/mesh.ino
+++ b/examples/mesh.ino
@@ -34,7 +34,12 @@ void setup() {
 		Serial.println("Mesh.listen() failed");
 	}
 	MESH.setIncomingMeshMsgHandler(meshCallback);
+
 #endif
+
+	short id = MESH.id();
+	Serial.print("Own stone id is ");
+	Serial.println(id);
 }
 
 void loop() {
@@ -50,8 +55,8 @@ void loop() {
 	if (counter % 10 == 0) {
 		// Send Mesh
 		Serial.println("Sending mesh msg");
-		uint8_t msg[2] = {22, 21};
-		uint8_t stoneId = 0; // broadcast
+		uint8_t msg[2] = {20, 19};
+		uint8_t stoneId = 6;
 		MESH.sendMeshMsg(msg, sizeof(msg), stoneId);
 	}
 #endif

--- a/examples/mesh.ino
+++ b/examples/mesh.ino
@@ -30,14 +30,14 @@ void setup() {
 
 #ifdef ROLE_RECEIVER
 	Serial.println("Start listening to mesh");
-	if (!MESH.listen()) {
+	if (!Mesh.listen()) {
 		Serial.println("Mesh.listen() failed");
 	}
-	MESH.setIncomingMeshMsgHandler(meshCallback);
+	Mesh.setIncomingMeshMsgHandler(meshCallback);
 
 #endif
 
-	short id = MESH.id();
+	short id = Mesh.id();
 	Serial.print("Own stone id is ");
 	Serial.println(id);
 }
@@ -45,9 +45,9 @@ void setup() {
 void loop() {
 #ifdef ROLE_RECEIVER
 	// Read Mesh
-	if (MESH.available()) {
+	if (Mesh.available()) {
 		MeshMsg msg;
-		MESH.readMeshMsg(&msg);
+		Mesh.readMeshMsg(&msg);
 		printMeshMsg(&msg);
 	}
 #endif
@@ -58,7 +58,7 @@ void loop() {
 		uint8_t msg[2] = {20, 19};
 		// use 0 as stoneId for broadcast
 		uint8_t stoneId = 0;
-		MESH.sendMeshMsg(msg, sizeof(msg), stoneId);
+		Mesh.sendMeshMsg(msg, sizeof(msg), stoneId);
 	}
 #endif
 	counter++;

--- a/examples/mesh_poll.ino
+++ b/examples/mesh_poll.ino
@@ -11,9 +11,13 @@ void printMeshMsg(MeshMsg* msg) {
 	Serial.println(msg->stoneId);
 	for (int i = 0; i < msg->dlen; i++) {
 		Serial.print(*(msg->dataPtr + i));
-		Serial.print(" ");
+		if (i + 1 == msg->dlen) {
+			Serial.println(" ");
+		}
+		else {
+			Serial.print(" ");
+		}
 	}
-	Serial.println("");
 }
 
 void meshCallback(MeshMsg msg) {
@@ -34,8 +38,6 @@ void setup() {
 }
 
 void loop() {
-	// Serial.println("Loop");
-
 #ifdef ROLE_RECEIVER
 	// Read Mesh
 	if (MESH.available()) {

--- a/examples/mesh_poll.ino
+++ b/examples/mesh_poll.ino
@@ -1,15 +1,21 @@
 #include <Mesh.h>
+#include <Serial.h>
 
 #define ROLE_RECEIVER
 // #define ROLE_TRANSMITTER
 
-Mesh mesh;
-
 uint32_t counter;
+
+void meshCallback(MeshMsg msg) {
+	Serial.println("mesh callback");
+}
 
 void setup() {
 	Serial.begin();
 	counter = 0;
+	MESH.begin();
+	// mesh.setIncomingMeshMsgHandler(meshCallback);
+
 }
 
 void loop() {
@@ -18,23 +24,25 @@ void loop() {
 
 #ifdef ROLE_RECEIVER
 	// Read Mesh
-	if (mesh.available()) {
+	if (MESH.available()) {
 		// Serial.println("Mesh message available");
-		uint8_t* msg_ptr = nullptr;
-		uint8_t stone_id = 0;
-		uint8_t size = mesh.readMeshMsg(&msg_ptr, &stone_id);
+		MeshMsg msg;
+		MESH.readMeshMsg(&msg);
+
+		Serial.println("Received mesh message:");
+		Serial.println(*(msg.dataPtr));
 
 		// Serial.print("Mesh msg from stone ");
 		// Serial.print((int)stone_id);
 		// Serial.print(" [");
 		// Serial.print((int)size);
 		// Serial.print("]: ");
-		int i = 0;
-		while (size != 0) {
-			Serial.print(*(msg_ptr+i));
-			size--;
-		}
-		Serial.println("");
+		// int i = 0;
+		// while (size != 0) {
+		// 	Serial.print(*(msg_ptr+i));
+		// 	size--;
+		// }
+		// Serial.println("");
 		// Serial.println((*msg_ptr) + *(msg_ptr+1));
 		// if (size != 2) {
 		// 	Serial.println("Incorrect size");
@@ -45,9 +53,9 @@ void loop() {
 	if (counter % 10 == 0) {
 		// Send Mesh
 		Serial.println("Sending mesh msg");
-		uint8_t msg[2] = {2, 3};
+		uint8_t msg[2] = {22, 21};
 		uint8_t stoneId = 0; // broadcast
-		mesh.sendMeshMsg(msg, sizeof(msg), stoneId);
+		MESH.sendMeshMsg(msg, sizeof(msg), stoneId);
 	}
 #endif
 	counter++;

--- a/examples/mesh_poll.ino
+++ b/examples/mesh_poll.ino
@@ -27,7 +27,7 @@ void setup() {
 #ifdef ROLE_RECEIVER
 	Serial.println("Start listening to mesh");
 	if (!MESH.listen()) {
-		Serial.println("Mesh::listen() failed");
+		Serial.println("Mesh.listen() failed");
 	}
 	MESH.setIncomingMeshMsgHandler(meshCallback);
 #endif

--- a/examples/mesh_poll.ino
+++ b/examples/mesh_poll.ino
@@ -1,5 +1,8 @@
 #include <Mesh.h>
 
+#define ROLE_RECEIVER
+// #define ROLE_TRANSMITTER
+
 Mesh mesh;
 
 uint32_t counter;
@@ -10,33 +13,43 @@ void setup() {
 }
 
 void loop() {
-	
-	Serial.println("Loop");
 
+	// Serial.println("Loop");
+
+#ifdef ROLE_RECEIVER
 	// Read Mesh
 	if (mesh.available()) {
-		Serial.println("Mesh messages available");
+		// Serial.println("Mesh message available");
 		uint8_t* msg_ptr = nullptr;
 		uint8_t stone_id = 0;
 		uint8_t size = mesh.readMeshMsg(&msg_ptr, &stone_id);
 
-		Serial.print("Stone id ");
-		Serial.print((short)stone_id);
-		Serial.print(" gave response [");
-		Serial.print((short)size);
-		Serial.print("]: '");
-		while (size-- != 0) {
-			Serial.print((short)*msg_ptr++);
+		// Serial.print("Mesh msg from stone ");
+		// Serial.print((int)stone_id);
+		// Serial.print(" [");
+		// Serial.print((int)size);
+		// Serial.print("]: ");
+		int i = 0;
+		while (size != 0) {
+			Serial.print(*(msg_ptr+i));
+			size--;
 		}
-		Serial.println("'");
+		Serial.println("");
+		// Serial.println((*msg_ptr) + *(msg_ptr+1));
+		// if (size != 2) {
+		// 	Serial.println("Incorrect size");
+		// }
 	}
-	if (counter % 5 == 0) {
+#endif
+#ifdef ROLE_TRANSMITTER
+	if (counter % 10 == 0) {
 		// Send Mesh
 		Serial.println("Sending mesh msg");
-		uint8_t msg[7] = {5,5,5,5,5,5,5};
-		uint8_t stoneId = 0;
+		uint8_t msg[2] = {2, 3};
+		uint8_t stoneId = 0; // broadcast
 		mesh.sendMeshMsg(msg, sizeof(msg), stoneId);
 	}
+#endif
 	counter++;
 }
 

--- a/examples/mesh_poll.ino
+++ b/examples/mesh_poll.ino
@@ -6,47 +6,42 @@
 
 uint32_t counter;
 
+void printMeshMsg(MeshMsg* msg) {
+	Serial.print("Received mesh message from stone ");
+	Serial.println(msg->stoneId);
+	for (int i = 0; i < msg->dlen; i++) {
+		Serial.print(*(msg->dataPtr + i));
+		Serial.print(" ");
+	}
+	Serial.println("");
+}
+
 void meshCallback(MeshMsg msg) {
-	Serial.println("mesh callback");
+	printMeshMsg(&msg);
 }
 
 void setup() {
 	Serial.begin();
 	counter = 0;
-	MESH.begin();
-	// mesh.setIncomingMeshMsgHandler(meshCallback);
 
+#ifdef ROLE_RECEIVER
+	Serial.println("Start listening to mesh");
+	if (!MESH.listen()) {
+		Serial.println("Mesh::listen() failed");
+	}
+	MESH.setIncomingMeshMsgHandler(meshCallback);
+#endif
 }
 
 void loop() {
-
 	// Serial.println("Loop");
 
 #ifdef ROLE_RECEIVER
 	// Read Mesh
 	if (MESH.available()) {
-		// Serial.println("Mesh message available");
 		MeshMsg msg;
 		MESH.readMeshMsg(&msg);
-
-		Serial.println("Received mesh message:");
-		Serial.println(*(msg.dataPtr));
-
-		// Serial.print("Mesh msg from stone ");
-		// Serial.print((int)stone_id);
-		// Serial.print(" [");
-		// Serial.print((int)size);
-		// Serial.print("]: ");
-		// int i = 0;
-		// while (size != 0) {
-		// 	Serial.print(*(msg_ptr+i));
-		// 	size--;
-		// }
-		// Serial.println("");
-		// Serial.println((*msg_ptr) + *(msg_ptr+1));
-		// if (size != 2) {
-		// 	Serial.println("Incorrect size");
-		// }
+		printMeshMsg(&msg);
 	}
 #endif
 #ifdef ROLE_TRANSMITTER

--- a/examples/outlet.ino
+++ b/examples/outlet.ino
@@ -42,7 +42,7 @@ void setup() {
 	// Set GPIO pin to OUTPUT, so we can write.
 	pinMode(GPIO0_PIN, OUTPUT);
 	digitalWrite(GPIO0_PIN, true);
-	
+
 	//pinMode(GPIO1_PIN, OUTPUT);
 	//digitalWrite(GPIO1_PIN, false);
 
@@ -57,11 +57,9 @@ void setup() {
 	// Set interrupt handler
 	//pinMode(BUTTON2_PIN, INPUT_PULLUP);
 	pinMode(BUTTON2_PIN, INPUT);
-	int result = attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, RISING);
-
-	Serial.write("attachInterrupt returns ");
-	Serial.write(result);
-	Serial.println(" ");
+	if (!attachInterrupt(digitalPinToInterrupt(BUTTON2_PIN), blink, CHANGE)) {
+		Serial.println("Setting button interrupt failed");
+	}
 
 }
 
@@ -71,7 +69,7 @@ void setup() {
 void loop() {
 	// We are able to use static variables.
 	counter++;
-	
+
 	if (counter % 5 == 0) {
 		if (state == LOW) {
 			Serial.println("State down");

--- a/include/Arduino.h
+++ b/include/Arduino.h
@@ -87,7 +87,7 @@ void analogWrite(uint8_t pin, int val);
 // @param isr      The interrupt service routine to call
 // @param mode     The options are LOW, CHANGE, RISING, FALLING, and HIGH.
 //
-int attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
+boolean attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
 
 // Mapping from digital pins to interrupts.
 uint8_t digitalPinToInterrupt(uint8_t pin);

--- a/include/Arduino.h
+++ b/include/Arduino.h
@@ -90,7 +90,7 @@ void analogWrite(uint8_t pin, int val);
 // @param isr      The interrupt service routine to call
 // @param mode     The options are LOW, CHANGE, RISING, FALLING, and HIGH.
 //
-boolean attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
+bool attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
 
 // Mapping from digital pins to interrupts.
 uint8_t digitalPinToInterrupt(uint8_t pin);

--- a/include/Arduino.h
+++ b/include/Arduino.h
@@ -10,6 +10,9 @@ extern "C" {
 #include <microapp.h>
 #include <stdint.h>
 
+typedef bool boolean;
+typedef uint8_t byte;
+
 //
 // Redefinitions for easy pin access. These do NOT correspond to physical pins on a specific board.
 // A maximum of 10 GPIO pins (0-9), 4 button pins (1-4) and 4 LED pins (1-4) are supported.
@@ -91,9 +94,6 @@ boolean attachInterrupt(uint8_t pin, void (*isr)(void), uint8_t mode);
 
 // Mapping from digital pins to interrupts.
 uint8_t digitalPinToInterrupt(uint8_t pin);
-
-typedef bool boolean;
-typedef uint8_t byte;
 
 // Return highest byte (8 bits) or second-lowest byte (for larger data types)
 byte highByte(short val);

--- a/include/ArduinoBLE.h
+++ b/include/ArduinoBLE.h
@@ -81,8 +81,10 @@ public:
 	 *
 	 * @param[in] eventType   Type of event to set callback for
 	 * @param[in] callback    The callback function to call upon a trigger
+	 *
+	 * @return                True if successful
 	 */
-	void setEventHandler(BleEventType eventType, void (*callback)(BleDevice));
+	bool setEventHandler(BleEventType eventType, void (*callback)(BleDevice));
 
 	/**
 	 * Sends command to bluenet to call registered microapp callback function upon receiving advertisements

--- a/include/ArduinoBLE.h
+++ b/include/ArduinoBLE.h
@@ -77,6 +77,26 @@ public:
 	}
 
 	/**
+	 * Initializes the BLE module
+	 *
+	 * @return true on success
+	 * @return false otherwise
+	 */
+	bool begin();
+
+	/**
+	 * Stops the BLE module
+	 */
+	void end();
+
+	/**
+	 * Poll for BLE events and handle them
+	 *
+	 * @param timeout
+	 */
+	void poll(int timeout = 0);
+
+	/**
 	 * Registers a callback function for scanned device event triggered within bluenet
 	 *
 	 * @param[in] eventType   Type of event to set callback for
@@ -85,6 +105,36 @@ public:
 	 * @return                True if successful
 	 */
 	bool setEventHandler(BleEventType eventType, void (*callback)(BleDevice));
+
+	/**
+	 * Query if another BLE device is connected
+	 *
+	 * @return true if another BLE device is connected
+	 * @return false otherwise
+	 */
+	bool connected();
+
+	/**
+	 * Disconnect any connected BLE device
+	 *
+	 * @return true on success
+	 * @return false otherwise
+	 */
+	bool disconnect();
+
+	/**
+	 * Get the MAC address of the own device
+	 *
+	 * @return String representation of the MAC address
+	 */
+	String address();
+
+	/**
+	 * Get the RSSI of the connected BLE device
+	 *
+	 * @return RSSI of connected device. 127 if not BLE device is connected
+	 */
+	int8_t rssi();
 
 	/**
 	 * Sends command to bluenet to call registered microapp callback function upon receiving advertisements
@@ -136,6 +186,10 @@ public:
 	 * @return                  BleDevice object representing the discovered device
 	 */
 	BleDevice available();
+
+/*
+ * The following functions do not exist in the ArduinoBle library
+ */
 
 	/**
 	 * Compares the scanned device device against the filter and returns true upon a match

--- a/include/ArduinoBLE.h
+++ b/include/ArduinoBLE.h
@@ -62,11 +62,6 @@ private:
 	bool _isScanning = false;
 
 	/*
-	 * Compares the scanned device device against the filter and returns true upon a match
-	 */
-	bool filterScanEvent(BleDevice rawDevice);
-
-	/*
 	 * Store callback contexts.
 	 */
 	BleSoftInterruptContext _bleSoftInterruptContext[MAX_SOFT_INTERRUPTS];
@@ -140,7 +135,14 @@ public:
 	 */
 	BleDevice available();
 
-protected:
+	/**
+	 * Compares the scanned device device against the filter and returns true upon a match
+	 *
+	 * @param[in] rawDevice  the scanned BLE device
+	 *
+	 */
+	bool filterScanEvent(BleDevice rawDevice);
+
 	/**
 	 * Get the currently set filter for scanned devices
 	 *

--- a/include/BleDevice.h
+++ b/include/BleDevice.h
@@ -70,6 +70,12 @@ public:
 	int8_t rssi();
 
 	/**
+	 * Get type of advertisement
+	 *
+	 */
+	uint8_t type();
+
+	/**
 	 * Returns whether the device has advertised a local name
 	 *
 	 * @return true    if the advertisement contains a local name field (either complete or shortened).

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -2,8 +2,101 @@
 
 #include <microapp.h>
 
-class Mesh {
+#define MESH_MSG_BUFFER_LEN 3
+
+typedef void (*ReceivedMeshMsgHandler)(MeshMsg);
+
+struct MeshMsgBufferEntry {
+	bool filled;
+	uint8_t stoneId;
+	uint8_t data[MICROAPP_MAX_MESH_MESSAGE_SIZE];
+	uint8_t dlen;
+};
+
+/**
+ * Wrapper class for mesh message
+ * This class itself contains only pointers to the actual mesh message data,
+ * which for read mesh messages is stored in the mesh buffer
+ * and for sent messages is stored on the user side.
+ * Since the actual data is stored somewhere else, the validity of a MeshMsg object
+ * is only guaranteed for the lifetime of the actual message data.
+ */
+class MeshMsg {
+private:
+	MeshMsg(){};
+
+	uint8_t _stoneId;
+	uint8_t* _dataPtr;
+	uint8_t _dlen;
+
 public:
+	MeshMsg(uint8_t stoneId, uint8_t* dataPtr, uint8_t dlen) {
+		_stoneId = stoneId;
+		_dataPtr = dataPtr;
+		_dlen = dlen;
+	}
+}
+
+// wrapper for class method
+int softInterruptMesh(void* args, void* buf);
+
+/**
+ * Mesh class for inter-crownstone messaging.
+ * There are two main methods of reading mesh messages:
+ * - Polling (via available() and readMeshMessage())
+ * - Interrupts (via setIncomingMeshMsgHandler())
+ * Sending mesh messages is supported via sendMeshMsg()
+ */
+class Mesh {
+private:
+	/**
+	 * Constructor
+	 */
+	Mesh();
+
+	/**
+	 * Buffer for storing incoming mesh messages
+	 * This is where the actual data is stored (for polling applications)
+	 * Note: A MeshMsgBufferEntry is max 10 bytes in size
+	 */
+	MeshMsgBufferEntry _incomingMeshMsgBuffer[MESH_MSG_BUFFER_LEN];
+
+	// If true, call the handler function registered by the user upon incoming mesh messages
+	bool _hasRegisteredIncomingMeshMsgHandler;
+
+	ReceivedMeshMsgHandler _registeredIncomingMeshMsgHandler;
+
+public:
+
+	static Mesh & getInstance() {
+		// Guaranteed to be destroyed.
+		static Mesh instance;
+
+		// Instantiated on first use.
+		return instance;
+	}
+
+	/**
+	 * Place a mesh message
+	 */
+	int handleIncomingMeshMsg(microapp_mesh_read_cmd_t* msg);
+
+	/**
+	 * Register a handler that will be called upon incoming mesh messages
+	 */
+	void setIncomingMeshMsgHandler(void (*handler)(MeshMsg*));
+
+	/**
+	 * Pop a message from the incoming mesh message buffer.
+	 * Note that the returned pointer is not memory safe.
+	 * It should only be used in local context.
+	 * If the message content needs to be saved, the caller
+	 * is responsible for copying the data to some memory-safe location.
+	 *
+	 * @return Pointer to a message
+	 */
+	MeshMsg* readMeshMsg();
+
 	/**
 	 * Send a mesh message.
 	 *
@@ -12,12 +105,12 @@ public:
 	 * @param[in] stoneId     ID of the Crownstone to send the message to, or 0 to send it to every Crownstone.
 	 */
 	void sendMeshMsg(uint8_t* msg, uint8_t msgSize, uint8_t stoneId);
-	
+
 	/**
 	 * Read a mesh message.
 	 *
 	 * @param[out] msg        Pointer that will be set to point to the message.
-	 * @param[out] msgSize    Pointer that will be set to point to the stone ID of the sender.
+	 * @param[out] stoneId    Pointer that will be set to point to the stone ID of the sender.
 	 * @return                Size of the message.
 	 */
 	uint8_t readMeshMsg(uint8_t** msg, uint8_t* stoneId);
@@ -29,3 +122,5 @@ public:
 	 */
 	bool available();
 };
+
+#define MESH Mesh::getInstance()

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -5,7 +5,7 @@
 #define MESH_MSG_BUFFER_LEN 3
 
 struct MeshMsgBufferEntry {
-	bool filled;
+	bool filled = false;
 	uint8_t stoneId;
 	uint8_t data[MICROAPP_MAX_MESH_MESSAGE_SIZE];
 	uint8_t dlen;
@@ -45,23 +45,18 @@ int softInterruptMesh(void* args, void* buf);
  * - Interrupts (via setIncomingMeshMsgHandler())
  * Sending mesh messages is supported via sendMeshMsg()
  */
-class Mesh {
+class MeshClass {
 private:
 	/**
 	 * Constructor
 	 */
-	Mesh();
+	MeshClass();
 
 	/**
 	 * Buffer for storing incoming mesh messages
 	 * This is where the actual data is stored (for polling applications)
 	 */
 	MeshMsgBufferEntry _incomingMeshMsgBuffer[MESH_MSG_BUFFER_LEN];
-
-	/**
-	 * Flag indicating whether an incoming mesh handler has been registered
-	 */
-	bool _hasRegisteredIncomingMeshMsgHandler;
 
 	/**
 	 * Handler for registered callbacks for incoming mesh messages
@@ -75,9 +70,9 @@ private:
 
 public:
 
-	static Mesh & getInstance() {
+	static MeshClass & getInstance() {
 		// Guaranteed to be destroyed.
-		static Mesh instance;
+		static MeshClass instance;
 
 		// Instantiated on first use.
 		return instance;
@@ -110,6 +105,7 @@ public:
 	bool available();
 
 	/**
+	 * Read a mesh message
 	 * Pop a message from the incoming mesh message buffer.
 	 * Note that the returned pointer is not memory safe.
 	 * It should only be used in local context.
@@ -137,4 +133,4 @@ public:
 	short id();
 };
 
-#define MESH Mesh::getInstance()
+#define Mesh MeshClass::getInstance()

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -48,9 +48,11 @@ int softInterruptMesh(void* args, void* buf);
 class MeshClass {
 private:
 	/**
-	 * Constructor
+	 * Constructors and copy constructors
 	 */
 	MeshClass();
+	MeshClass(MeshClass const&);
+	void operator=(MeshClass const&);
 
 	/**
 	 * Buffer for storing incoming mesh messages

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -63,7 +63,15 @@ private:
 	 */
 	bool _hasRegisteredIncomingMeshMsgHandler;
 
+	/**
+	 * Handler for registered callbacks for incoming mesh messages
+	 */
 	ReceivedMeshMsgHandler _registeredIncomingMeshMsgHandler;
+
+	/**
+	 * Own stone id
+	 */
+	uint8_t _stoneId;
 
 public:
 
@@ -121,6 +129,12 @@ public:
 	 */
 	void sendMeshMsg(uint8_t* msg, uint8_t msgSize, uint8_t stoneId);
 
+	/**
+	 * Get own stone id
+	 *
+	 * If already asked bluenet before, won't ask again but use cached value
+	 */
+	short id();
 };
 
 #define MESH Mesh::getInstance()

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -2,7 +2,7 @@
 
 #include <microapp.h>
 
-#define MESH_MSG_BUFFER_LEN 3
+#define MESH_MSG_BUFFER_LEN 2
 
 struct MeshMsgBufferEntry {
 	bool filled = false;
@@ -59,6 +59,13 @@ private:
 	 * This is where the actual data is stored (for polling applications)
 	 */
 	MeshMsgBufferEntry _incomingMeshMsgBuffer[MESH_MSG_BUFFER_LEN];
+
+
+	/**
+	 * Available mesh message passed to the user
+	 * Requires a separate memory location than _incomingMeshMsgBuffer since those can be overwritten
+	 */
+	MeshMsgBufferEntry _availableMeshMsg;
 
 	/**
 	 * Handler for registered callbacks for incoming mesh messages

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -75,13 +75,13 @@ public:
 	}
 
 	/**
-	 * Initialize the mesh object. Bluenet will start forwarding microapp mesh messages
-	 * after calling this function.
+	 * Initialize the mesh object for reading. Bluenet will start
+	 * forwarding microapp mesh messages after calling this function.
 	 *
 	 * @return true if bluenet successfully registered an interrupt service routine
 	 * @return false if registering an interrupt service routine failed
 	 */
-	bool begin();
+	bool listen();
 
 	/**
 	 * Place a mesh message

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -55,11 +55,12 @@ private:
 	/**
 	 * Buffer for storing incoming mesh messages
 	 * This is where the actual data is stored (for polling applications)
-	 * Note: A MeshMsgBufferEntry is max 10 bytes in size
 	 */
 	MeshMsgBufferEntry _incomingMeshMsgBuffer[MESH_MSG_BUFFER_LEN];
 
-	// If true, call the handler function registered by the user upon incoming mesh messages
+	/**
+	 * Flag indicating whether an incoming mesh handler has been registered
+	 */
 	bool _hasRegisteredIncomingMeshMsgHandler;
 
 	ReceivedMeshMsgHandler _registeredIncomingMeshMsgHandler;

--- a/include/microapp.h
+++ b/include/microapp.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 // SoftInterrupt functions
-typedef void (*softInterruptFunction)(void *, void *);
+typedef int (*softInterruptFunction)(void *, void *);
 
 const uint8_t SOFT_INTERRUPT_TYPE_BLE = 1;
 const uint8_t SOFT_INTERRUPT_TYPE_PIN = 2;

--- a/include/microapp.h
+++ b/include/microapp.h
@@ -10,8 +10,9 @@ extern "C" {
 // SoftInterrupt functions
 typedef int (*softInterruptFunction)(void *, void *);
 
-const uint8_t SOFT_INTERRUPT_TYPE_BLE = 1;
-const uint8_t SOFT_INTERRUPT_TYPE_PIN = 2;
+const uint8_t SOFT_INTERRUPT_TYPE_BLE  = 1;
+const uint8_t SOFT_INTERRUPT_TYPE_PIN  = 2;
+const uint8_t SOFT_INTERRUPT_TYPE_MESH = 3;
 
 // Store softInterrupts in the microapp
 struct soft_interrupt_t {

--- a/include/microapp.h
+++ b/include/microapp.h
@@ -36,8 +36,6 @@ typedef microapp_ble_device_t ble_dev_t;
 
 // Create long-form version for who wants
 
-// typedef message_t microapp_message_t;
-
 #define OUTPUT CS_MICROAPP_COMMAND_PIN_WRITE
 #define INPUT CS_MICROAPP_COMMAND_PIN_READ
 #define TOGGLE CS_MICROAPP_COMMAND_PIN_TOGGLE
@@ -51,8 +49,6 @@ typedef microapp_ble_device_t ble_dev_t;
 #define I2C_READ CS_MICROAPP_COMMAND_TWI_READ
 #define I2C_WRITE CS_MICROAPP_COMMAND_TWI_WRITE
 
-//#define HIGH                 CS_MICROAPP_COMMAND_SWITCH_ON
-//#define LOW                  CS_MICROAPP_COMMAND_SWITCH_OFF
 
 const uint8_t LOW = 0;
 const uint8_t HIGH = !LOW;

--- a/include/microapp.h
+++ b/include/microapp.h
@@ -120,9 +120,9 @@ int sendMessage();
 int registerSoftInterrupt(soft_interrupt_t *interrupt);
 
 /**
- * Evoke a previously registered softInterrupt.
+ * Remove a registered softInterrupt locally
  */
-int evokeSoftInterrupt(uint8_t type, uint8_t id, uint8_t *msg);
+int removeRegisteredSoftInterrupt(uint8_t type, uint8_t id);
 
 /**
  * Handle softInterrupts.

--- a/src/Arduino.c
+++ b/src/Arduino.c
@@ -103,6 +103,9 @@ bool attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
 
 	result = sendMessage();
 	if (result != ERR_MICROAPP_SUCCESS) {
+		// Remove locally registered interrupt
+		result = removeRegisteredSoftInterrupt(SOFT_INTERRUPT_TYPE_PIN, interrupt);
+		// Do nothing with the result. We return false anyway
 		return false;
 	}
 	return true;

--- a/src/Arduino.c
+++ b/src/Arduino.c
@@ -22,7 +22,9 @@ uint8_t interruptToDigitalPin(uint8_t interrupt) {
 
 // The mode here is INPUT, OUTPUT, INPUT_PULLUP, etc.
 void pinMode(uint8_t pin, uint8_t mode) {
-	if (!pinExists(pin)) return;
+	if (!pinExists(pin)) {
+		return;
+	}
 
 	uint8_t *payload = getOutgoingMessagePayload();
 	microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(payload);
@@ -36,7 +38,9 @@ void pinMode(uint8_t pin, uint8_t mode) {
 }
 
 void digitalWrite(uint8_t pin, uint8_t val) {
-	if (!pinExists(pin)) return;
+	if (!pinExists(pin)) {
+		return;
+	}
 
 	uint8_t *payload = getOutgoingMessagePayload();
 	microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(payload);
@@ -50,7 +54,9 @@ void digitalWrite(uint8_t pin, uint8_t val) {
 }
 
 int digitalRead(uint8_t pin) {
-	if (!pinExists(pin)) return -1;
+	if (!pinExists(pin)) {
+		return -1;
+	}
 
 	uint8_t *payload = getOutgoingMessagePayload();
 	microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(payload);
@@ -74,7 +80,9 @@ int digitalRead(uint8_t pin) {
  * For now, just keep it like this because it doesn't hurt to have a pin configured twice.
  */
 bool attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
-	if (!pinExists(interruptToDigitalPin(interrupt))) return false;
+	if (!pinExists(interruptToDigitalPin(interrupt))) {
+		return false;
+	}
 
 	soft_interrupt_t softInterrupt;
 	softInterrupt.type = SOFT_INTERRUPT_TYPE_PIN;

--- a/src/Arduino.c
+++ b/src/Arduino.c
@@ -3,15 +3,19 @@
 
 #include <ipc/cs_IpcRamData.h>
 
-bool pinExists(uint8_t pin) {
-	// first check, more checks on bluenet side
+boolean pinExists(uint8_t pin) {
+	// First check, more checks on bluenet side
 	return (pin < NUMBER_OF_PINS);
 }
 
+// Convert a pin to a virtual pin ('interrupt' in Arduino language)
+// This is a trivial mapping, here to comply with Arduino syntax
 uint8_t digitalPinToInterrupt(uint8_t pin) {
 	return pin;
 }
 
+// Convert a virtual pin back to a pin
+// This is a trivial mapping, see digitalPinToInterrupt()
 uint8_t interruptToDigitalPin(uint8_t interrupt) {
 	return interrupt;
 }
@@ -49,7 +53,6 @@ int digitalRead(uint8_t pin) {
 	if (!pinExists(pin)) return -1;
 
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t *buffer = getOutgoingMessageBuffer();
 	microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(payload);
 	pin_cmd->header.cmd = CS_MICROAPP_COMMAND_PIN;
 	pin_cmd->pin = pin;
@@ -85,7 +88,6 @@ int attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
 	uint8_t *payload = getOutgoingMessagePayload();
 	microapp_pin_cmd_t* pin_cmd = reinterpret_cast<microapp_pin_cmd_t*>(payload);
 	pin_cmd->header.cmd = CS_MICROAPP_COMMAND_PIN;
-	// the pin field actually contains the corresponding interrupt
 	pin_cmd->pin = interrupt;
 	pin_cmd->opcode1 = CS_MICROAPP_COMMAND_PIN_MODE;
 	pin_cmd->opcode2 = CS_MICROAPP_COMMAND_PIN_INPUT_PULLUP;

--- a/src/Arduino.c
+++ b/src/Arduino.c
@@ -73,16 +73,16 @@ int digitalRead(uint8_t pin) {
  * Actually, this again sets also the values that are set with pinMode. That's redundant.
  * For now, just keep it like this because it doesn't hurt to have a pin configured twice.
  */
-int attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
-	if (!pinExists(interruptToDigitalPin(interrupt))) return -1;
+boolean attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
+	if (!pinExists(interruptToDigitalPin(interrupt))) return false;
 
 	soft_interrupt_t softInterrupt;
 	softInterrupt.type = SOFT_INTERRUPT_TYPE_PIN;
 	softInterrupt.id = interrupt;
 	softInterrupt.softInterruptFunc = reinterpret_cast<softInterruptFunction>(isr);
 	int result = registerSoftInterrupt(&softInterrupt);
-	if (result < 0) {
-		return result;
+	if (result != ERR_MICROAPP_SUCCESS) {
+		return false;
 	}
 
 	uint8_t *payload = getOutgoingMessagePayload();
@@ -94,7 +94,10 @@ int attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
 	pin_cmd->value = mode;
 
 	result = sendMessage();
-	return result;
+	if (result != ERR_MICROAPP_SUCCESS) {
+		return false;
+	}
+	return true;
 }
 
 

--- a/src/Arduino.c
+++ b/src/Arduino.c
@@ -3,7 +3,7 @@
 
 #include <ipc/cs_IpcRamData.h>
 
-boolean pinExists(uint8_t pin) {
+bool pinExists(uint8_t pin) {
 	// First check, more checks on bluenet side
 	return (pin < NUMBER_OF_PINS);
 }
@@ -73,7 +73,7 @@ int digitalRead(uint8_t pin) {
  * Actually, this again sets also the values that are set with pinMode. That's redundant.
  * For now, just keep it like this because it doesn't hurt to have a pin configured twice.
  */
-boolean attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
+bool attachInterrupt(uint8_t interrupt, void (*isr)(void), uint8_t mode) {
 	if (!pinExists(interruptToDigitalPin(interrupt))) return false;
 
 	soft_interrupt_t softInterrupt;

--- a/src/ArduinoBLE.cpp
+++ b/src/ArduinoBLE.cpp
@@ -16,6 +16,7 @@ int softInterruptBle(void* args, void* buf) {
 	}
 
 	// Based on the id (=type) of interrupt we will take action
+	// This could probably also be done by checking dev->header.interruptId
 	switch (context->id) {
 		case BleEventDeviceScanned: {
 			// Create temporary object on the stack

--- a/src/ArduinoBLE.cpp
+++ b/src/ArduinoBLE.cpp
@@ -68,7 +68,7 @@ bool Ble::setEventHandler(BleEventType type, void (*eventHandler)(BleDevice)) {
 	softInterrupt.softInterruptFunc = softInterruptBle;
 	softInterrupt.arg               = &_bleSoftInterruptContext[softInterruptContextId];
 	int result = registerSoftInterrupt(&softInterrupt);
-	if (result < 0) {
+	if (result != ERR_MICROAPP_SUCCESS) {
 		// No empty interrupt slots available on microapp side
 		return false;
 	}

--- a/src/ArduinoBLE.cpp
+++ b/src/ArduinoBLE.cpp
@@ -1,82 +1,31 @@
 #include <ArduinoBLE.h>
 
-Ble::Ble() {
-	for (int i = 0; i < MAX_SOFT_INTERRUPTS; i++) {
-		_bleSoftInterruptContext[i].eventHandler = nullptr;
-		_bleSoftInterruptContext[i].filled        = false;
-	}
-}
-
-bool Ble::filterScanEvent(BleDevice device) {
-	switch (_activeFilter.type) {
-		case BleFilterAddress: {
-			if (device._address != _activeFilter.address) {
-				return false;
-			}
-			break;
-		}
-		case BleFilterLocalName: {
-			if (!device.hasLocalName()) {
-				return false;
-			}
-			String deviceName = device.localName();
-			if (deviceName.length() != _activeFilter.len) {
-				return false;
-			}
-			// compare local name to name in filter
-			if (memcmp(deviceName.c_str(), _activeFilter.name, _activeFilter.len) != 0) {
-				return false;
-			}
-			break;
-		}
-		case BleFilterUuid: {
-			// TODO: refactor. Now filters ads of type service data with as
-			// first element the filtered uuid, which is not the same as what
-			// the official ArduinoBLE library does
-			data_ptr_t serviceData;
-			if (!device.findAdvertisementDataType(GapAdvType::ServiceData, &serviceData)) {
-				return false;
-			}
-			uint16_t uuid = ((serviceData.data[1] << 8) | serviceData.data[0]);
-			if (uuid != _activeFilter.uuid) {
-				return false;
-			}
-			break;
-		}
-		case BleFilterNone:
-		default: break;
-	}
-	return true;
-}
-
 /*
  * An ordinary C function to keep the softInterrupt simple.
  */
-void softInterruptBle(void* args, void* buf) {
+int softInterruptBle(void* args, void* buf) {
 	microapp_ble_device_t* dev       = (microapp_ble_device_t*)buf;
 	BleSoftInterruptContext* context = (BleSoftInterruptContext*)args;
 
 	if (!context->eventHandler) {
-		uint8_t *payload = getOutgoingMessagePayload();
-		//io_buffer_t* buffer = getOutgoingMessageBuffer();
-		microapp_cmd_t* cmd = (microapp_cmd_t*)(payload);
-		cmd->cmd            = CS_MICROAPP_COMMAND_SOFT_INTERRUPT_ERROR;
-		cmd->id             = context->id;
-		sendMessage();
-		return;
+		return -1;
 	}
 
+	// TODO: do something with type of softInterrupt. For now assume scan event
 	// Create temporary object on the stack
 	BleDevice bleDevice = BleDevice(*dev);
-	// Call the event handler with a copy of this object
-	context->eventHandler(bleDevice);
+	if (BLE.filterScanEvent(bleDevice)) {
+		// Call the event handler with a copy of this object
+		context->eventHandler(bleDevice);
+	}
+	return 0;
+}
 
-	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t* buffer = getOutgoingMessageBuffer();
-	microapp_cmd_t* cmd = (microapp_cmd_t*)(payload);
-	cmd->cmd            = CS_MICROAPP_COMMAND_SOFT_INTERRUPT_END;
-	cmd->id             = context->id;
-	sendMessage();
+Ble::Ble() {
+	for (int i = 0; i < MAX_SOFT_INTERRUPTS; i++) {
+		_bleSoftInterruptContext[i].eventHandler = nullptr;
+		_bleSoftInterruptContext[i].filled       = false;
+	}
 }
 
 /*
@@ -94,14 +43,13 @@ void Ble::setEventHandler(BleEventType type, void (*eventHandler)(BleDevice)) {
 	}
 	if (softInterruptContextId < 0) {
 		Serial.println("No space for new event handler");
-		return;
+		return; // TODO: add return type to function
 	}
 	BleSoftInterruptContext& context = _bleSoftInterruptContext[softInterruptContextId];
 
 	Serial.println("Setting event handler");
 	// TODO: do something with type. For now assume type is BleEventDeviceScanned
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t* buffer         = getOutgoingMessageBuffer();
 	microapp_ble_cmd_t* ble_cmd = (microapp_ble_cmd_t*)(payload);
 	ble_cmd->header.cmd         = CS_MICROAPP_COMMAND_BLE;
 	ble_cmd->opcode             = CS_MICROAPP_COMMAND_BLE_SCAN_SET_HANDLER;
@@ -172,15 +120,8 @@ bool Ble::stopScan() {
 		return true;
 	}
 
-	// Serial.println("Stopping BLE device scanning");
-
-	_activeFilter.type = BleFilterNone;  // reset filter
-
-	// send a message to bluenet commanding it to stop forwarding ads to
-	// microapp
-	// microapp_ble_cmd_t *ble_cmd = (microapp_ble_cmd_t*)&global_buf_out;
+	// send a message to bluenet commanding it to stop forwarding ads to microapp
 	uint8_t *payload = getOutgoingMessagePayload();
-	//io_buffer_t* buffer         = getOutgoingMessageBuffer();
 	microapp_ble_cmd_t* ble_cmd = (microapp_ble_cmd_t*)(payload);
 
 	ble_cmd->header.ack = false;
@@ -193,12 +134,60 @@ bool Ble::stopScan() {
 	if (!success) {
 		return success;
 	}
+
+	_activeFilter.type = BleFilterNone;  // reset filter
 	_isScanning = false;
+
 	return success;
 }
 
 BleDevice Ble::available() {
 	return _activeDevice;
+}
+
+bool Ble::filterScanEvent(BleDevice device) {
+	if (!_isScanning) {  // return false by default if not scanning
+		return false;
+	}
+	switch (_activeFilter.type) {
+		case BleFilterAddress: {
+			if (device._address != _activeFilter.address) {
+				return false;
+			}
+			break;
+		}
+		case BleFilterLocalName: {
+			if (!device.hasLocalName()) {
+				return false;
+			}
+			String deviceName = device.localName();
+			if (deviceName.length() != _activeFilter.len) {
+				return false;
+			}
+			// compare local name to name in filter
+			if (memcmp(deviceName.c_str(), _activeFilter.name, _activeFilter.len) != 0) {
+				return false;
+			}
+			break;
+		}
+		case BleFilterUuid: {
+			// TODO: refactor. Now filters ads of type service data with as
+			// first element the filtered uuid, which is not the same as what
+			// the official ArduinoBLE library does
+			data_ptr_t serviceData;
+			if (!device.findAdvertisementDataType(GapAdvType::ServiceData, &serviceData)) {
+				return false;
+			}
+			uint16_t uuid = ((serviceData.data[1] << 8) | serviceData.data[0]);
+			if (uuid != _activeFilter.uuid) {
+				return false;
+			}
+			break;
+		}
+		case BleFilterNone:
+		default: break;
+	}
+	return true;
 }
 
 BleFilter* Ble::getFilter() {

--- a/src/BleDevice.cpp
+++ b/src/BleDevice.cpp
@@ -18,6 +18,10 @@ int8_t BleDevice::rssi() {
 	return _device.rssi;
 }
 
+uint8_t BleDevice::type() {
+	return _device.type;
+}
+
 bool BleDevice::hasLocalName() {
 	if (!_flags.flags.checkedLocalName) { // if not yet checked
 		data_ptr_t cln;

--- a/src/BleDevice.cpp
+++ b/src/BleDevice.cpp
@@ -18,10 +18,6 @@ int8_t BleDevice::rssi() {
 	return _device.rssi;
 }
 
-uint8_t BleDevice::type() {
-	return _device.type;
-}
-
 bool BleDevice::hasLocalName() {
 	if (!_flags.flags.checkedLocalName) { // if not yet checked
 		data_ptr_t cln;
@@ -63,8 +59,6 @@ bool BleDevice::connect() {
 	ble_cmd->header.cmd = CS_MICROAPP_COMMAND_BLE;
 	ble_cmd->opcode = CS_MICROAPP_COMMAND_BLE_CONNECT;
 	memcpy(ble_cmd->addr, _address.getBytes(), MAC_ADDRESS_LENGTH);
-
-//	global_buf_out.length = sizeof(microapp_ble_cmd_t);
 
 	// TODO: sendMessage should return ERR_SUCCESS (0) on success
 	//       More importantly, this only communicates the intent of a connection.

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,5 +1,72 @@
 #include <Mesh.h>
 
+int softInterruptMesh(void* args, void* buf) {
+	microapp_mesh_read_cmd_t* msg = (microapp_mesh_read_cmd_t*)buf;
+	return MESH.handleIncomingMeshMsg(msg);
+}
+
+Mesh::Mesh() {
+	for (int i=0; i<MESH_MSG_BUFFER_LEN; i++) {
+		_incomingMeshMsgBuffer[i].filled = false;
+	}
+	_hasRegisteredIncomingMeshMsgHandler = false;
+	_registeredIncomingMeshMsgHandler = nullptr;
+}
+
+int Mesh::handleIncomingMeshMsg(microapp_mesh_read_cmd_t* msg) {
+	// If a handler is registered, we do not need to copy anything to the buffer,
+	// since the handler will deal with it right away.
+	// The microapp's softInterrupt handler has copied the msg to a localCopy
+	// so there is no worry of overwriting the msg upon a bluenet roundtrip
+	if (_hasRegisteredIncomingMeshMsgHandler) {
+		MeshMsg handlerMsg = MeshMsg(msg->stoneId, msg->data, msg->dlen);
+		_registeredIncomingMeshMsgHandler(&handlerMsg);
+		return 0;
+	}
+	// Add msg to buffer or discard if full
+	// Q: is it not more logical to discard oldest?
+	// that will lead to more memcpy calls however
+	bool full = true;
+	int i;
+	for (i=0; i<MESH_MSG_BUFFER_LEN; i++) {
+		if (!_incomingMeshMsgBuffer[i].filled) {
+			full = false;
+			break;
+		}
+	}
+	if (full) {
+		// discard message
+		return -1;
+	}
+	MeshMsgBufferEntry& copy = _incomingMeshMsgBuffer[i];
+	copy.stoneId = msg->stoneId;
+	copy.dlen = msg->dlen;
+	memcpy(copy.data, msg->data, msg->dlen);
+	copy.filled = true;
+
+	return 0;
+}
+
+void Mesh::setIncomingMeshMsgHandler(void (*handler)(MeshMsg*)) {
+	_hasRegisteredIncomingMeshMsgHandler = true;
+	_registeredIncomingMeshMsgHandler = handler;
+}
+
+MeshMsg* Mesh::readMeshMsg() {
+	for (int i=MESH_MSG_BUFFER_LEN-1; i>=0; i--) {
+		if (_incomingMeshMsgBuffer[i].filled) {
+			_incomingMeshMsgBuffer[i].filled = false;
+			MeshMsg msg = MeshMsg(	_incomingMeshMsgBuffer[i].stoneId,
+									_incomingMeshMsgBuffer[i].data,
+									_incomingMeshMsgBuffer[i].dlen);
+			return &msg;
+		}
+	}
+}
+
+///////////////////////////////////////////////////////////////////
+// old
+
 void Mesh::sendMeshMsg(uint8_t* msg, uint8_t msgSize, uint8_t stoneId) {
 	uint8_t* payload = getOutgoingMessagePayload();
 	microapp_mesh_send_cmd_t* cmd = (microapp_mesh_send_cmd_t*)(payload);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -104,8 +104,8 @@ void Mesh::readMeshMsg(MeshMsg* msg) {
 void Mesh::sendMeshMsg(uint8_t* msg, uint8_t msgSize, uint8_t stoneId) {
 	uint8_t* payload = getOutgoingMessagePayload();
 	microapp_mesh_send_cmd_t* cmd = (microapp_mesh_send_cmd_t*)(payload);
-	cmd->mesh_header.header.cmd   = CS_MICROAPP_COMMAND_MESH;
-	cmd->mesh_header.opcode       = CS_MICROAPP_COMMAND_MESH_SEND;
+	cmd->meshHeader.header.cmd   = CS_MICROAPP_COMMAND_MESH;
+	cmd->meshHeader.opcode       = CS_MICROAPP_COMMAND_MESH_SEND;
 	cmd->stoneId                  = stoneId;
 
 	int msgSizeSent = msgSize;
@@ -127,12 +127,12 @@ short Mesh::id() {
 	// If not, ask bluenet via a MESH_GET_INFO message
 	uint8_t* payload = getOutgoingMessagePayload();
 	microapp_mesh_info_cmd_t* cmd = (microapp_mesh_info_cmd_t*)(payload);
-	cmd->mesh_header.header.cmd = CS_MICROAPP_COMMAND_MESH;
-	cmd->mesh_header.header.ack = false;
-	cmd->mesh_header.opcode = CS_MICROAPP_COMMAND_MESH_GET_INFO;
+	cmd->meshHeader.header.cmd = CS_MICROAPP_COMMAND_MESH;
+	cmd->meshHeader.header.ack = false;
+	cmd->meshHeader.opcode = CS_MICROAPP_COMMAND_MESH_GET_INFO;
 	sendMessage();
 
-	if (cmd->mesh_header.header.ack) {
+	if (cmd->meshHeader.header.ack) {
 		_stoneId = cmd->stoneId;
 	}
 	return _stoneId;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -42,7 +42,7 @@ int MeshClass::handleIncomingMeshMsg(microapp_mesh_read_cmd_t* msg) {
 	if (_registeredIncomingMeshMsgHandler != nullptr) {
 		MeshMsg handlerMsg = MeshMsg(msg->stoneId, msg->data, msg->dlen);
 		_registeredIncomingMeshMsgHandler(handlerMsg);
-		return 0;
+		return ERR_MICROAPP_SUCCESS;
 	}
 	// Add msg to buffer or discard if full
 	// Q: is it not more logical to discard oldest?
@@ -57,7 +57,7 @@ int MeshClass::handleIncomingMeshMsg(microapp_mesh_read_cmd_t* msg) {
 	}
 	if (full) {
 		// discard message
-		return -1;
+		return ERR_MICROAPP_NO_SPACE;
 	}
 	MeshMsgBufferEntry& copy = _incomingMeshMsgBuffer[i];
 	copy.stoneId = msg->stoneId;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -23,7 +23,7 @@ bool Mesh::listen() {
 	softInterrupt.type = SOFT_INTERRUPT_TYPE_MESH;
 	softInterrupt.softInterruptFunc = softInterruptMesh;
 	int result = registerSoftInterrupt(&softInterrupt);
-	if (result < 0) {
+	if (result != ERR_MICROAPP_SUCCESS) {
 		// No empty interrupt slots available
 		return false;
 	}

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,4 +1,5 @@
 #include <Mesh.h>
+#include <Serial.h>
 
 int softInterruptMesh(void* args, void* buf) {
 	microapp_mesh_read_cmd_t* msg = (microapp_mesh_read_cmd_t*)buf;
@@ -13,10 +14,10 @@ Mesh::Mesh() {
 	_registeredIncomingMeshMsgHandler = nullptr;
 }
 
-bool Mesh::begin() {
-	// Register soft interrupt
+bool Mesh::listen() {
+	// Register soft interrupt locally
 	soft_interrupt_t softInterrupt;
-	softInterrupt.id = 23;
+	softInterrupt.id = 0;
 	softInterrupt.type = SOFT_INTERRUPT_TYPE_MESH;
 	softInterrupt.softInterruptFunc = softInterruptMesh;
 	registerSoftInterrupt(&softInterrupt);

--- a/src/microapp.c
+++ b/src/microapp.c
@@ -229,7 +229,7 @@ int handleBluenetRequest(microapp_cmd_t* cmd) {
 
 	uint8_t *payload = getOutgoingMessagePayload();
 	microapp_cmd_t* outCmd = (microapp_cmd_t*)(payload);
-	if (result < 0) {
+	if (result != ERR_MICROAPP_SUCCESS) {
 		outCmd->cmd = CS_MICROAPP_COMMAND_SOFT_INTERRUPT_ERROR;
 	}
 	else {

--- a/src/microapp.c
+++ b/src/microapp.c
@@ -329,6 +329,10 @@ int handleSoftInterrupt(microapp_cmd_t* msg) {
 			result = handleSoftInterruptInternal(SOFT_INTERRUPT_TYPE_PIN, msg->id, (uint8_t*)msg);
 			break;
 		}
+		case CS_MICROAPP_COMMAND_MESH: {
+			result = handleSoftInterruptInternal(SOFT_INTERRUPT_TYPE_MESH, msg->id, (uint8_t*)msg);
+			break;
+		}
 	}
 	return result;
 }

--- a/src/microapp.c
+++ b/src/microapp.c
@@ -280,6 +280,19 @@ int registerSoftInterrupt(soft_interrupt_t* interrupt) {
 	return ERR_MICROAPP_NO_SPACE;
 }
 
+int removeRegisteredSoftInterrupt(uint8_t type, uint8_t id) {
+	for (int i = 0; i < MAX_SOFT_INTERRUPTS; ++i) {
+		if (!softInterrupt[i].registered) {
+			continue;
+		}
+		if (softInterrupt[i].type == type && softInterrupt[i].id == id) {
+			softInterrupt[i].registered = false;
+			return ERR_MICROAPP_SUCCESS;
+		}
+	}
+	return ERR_MICROAPP_SOFT_INTERRUPT_NOT_REGISTERED;
+}
+
 int countRegisteredSoftInterrupts() {
 	int result = 0;
 	for (int i = 0; i < MAX_SOFT_INTERRUPTS; ++i) {

--- a/src/microapp.c
+++ b/src/microapp.c
@@ -1,8 +1,6 @@
 #include <ipc/cs_IpcRamData.h>
 #include <microapp.h>
 
-#include <Serial.h>
-
 // Define array with soft interrupts
 soft_interrupt_t softInterrupt[MAX_SOFT_INTERRUPTS];
 
@@ -171,11 +169,11 @@ int8_t getNewItemInQueue() {
  * Handle incoming requests from bluenet (probably soft interrupts).
  */
 int handleBluenetRequest(microapp_cmd_t* cmd) {
-	int result = 0;
+	int result = ERR_MICROAPP_SUCCESS;
 
 	// There is no actual request (no problem, just return)
 	if (cmd->ack != CS_ACK_BLUENET_MICROAPP_REQUEST) {
-		return result;
+		return ERR_MICROAPP_SUCCESS;
 	}
 
 	microapp_soft_interrupt_cmd_t* request = reinterpret_cast<microapp_soft_interrupt_cmd_t*>(cmd);
@@ -212,7 +210,7 @@ int handleBluenetRequest(microapp_cmd_t* cmd) {
 	result = callbackFunctionIntoBluenet(CS_MICROAPP_CALLBACK_SIGNAL, &io_buffer);
 
 	if (queueIndex < 0) {
-		result = -1;
+		result = ERR_MICROAPP_NO_SPACE;
 	}
 	else { // call handleSoftInterrupt and mark the localQueue entry as empty again
 		// Q: Under what circumstances will the queue grow beyond 1 entry?
@@ -341,10 +339,6 @@ int handleSoftInterrupt(microapp_cmd_t* msg) {
 			// interruptCmd not known
 			return ERR_MICROAPP_UNKNOWN_PROTOCOL;
 		}
-	}
-	if (result < 0) {
-		Serial.print("handleSoftInterrupt error: ");
-		Serial.println(result);
 	}
 	return result;
 }

--- a/src/microapp.c
+++ b/src/microapp.c
@@ -215,6 +215,10 @@ int handleBluenetRequest(microapp_cmd_t* cmd) {
 		result = -1;
 	}
 	else { // call handleSoftInterrupt and mark the localQueue entry as empty again
+		// Q: Under what circumstances will the queue grow beyond 1 entry?
+		// A: If bluenet comes with a second request before the first softInterrupt is handled
+		// That only seems possible if handleSoftInterrupt yields back to bluenet
+		// which tbh I don't see happening easily, maybe with a delay call in a user softInterrupt handler?
 		queue_t* localCopy = &localQueue[queueIndex];
 		memcpy(localCopy->buffer, request, MAX_PAYLOAD);
 		microapp_cmd_t* msg = reinterpret_cast<microapp_cmd_t*>(localCopy->buffer);


### PR DESCRIPTION
Also includes a bugfix as referenced within https://github.com/crownstone/crownstone-microapp/pull/12, so that one can be closed if this is merged.

A corresponding PR is available for the bluenet repo here: https://github.com/crownstone/bluenet/pull/167

### Main changes
* Refactor Mesh class to work with softInterrupt infrastructure (see bluenet PR). Fixes https://github.com/crownstone/crownstone-microapp/issues/13. Makes Mesh class a singleton like BLE.
* Fixes https://github.com/crownstone/crownstone-microapp/issues/15
* Add interrupt example script where multiple types of interrupts (gpio, mesh, ble) are tested
* Make some updates to BLE scanning and GPIO to make code more readable and make the softInterrupts work similarly.

Changes have been tested on nRF52832 boards. 

### Some open questions/issues:
* Mesh payload is really small (7 bytes, with 9 bytes overhead = 16 bytes). In theory the microapp payload is 48 bytes. What is limiting the mesh payload size specifically?
* The microapp controller will throttle calls to the microapp per tick (which is good in general). If BLE scanning is enabled in an environment with a lot of BLE traffic, then scanned devices may flood these calls with unfiltered scanned devices, and hence other types of interrupts (e.g. gpio, mesh) which are generally less common may not reach the microapp. Throttling specifically BLE scanned devices (e.g. filtering on rssi or address) could be a solution.