### PR TITLE
Add power usage and presence classes and example apps

### DIFF
--- a/examples/power.ino
+++ b/examples/power.ino
@@ -1,0 +1,15 @@
+#include <Arduino.h>
+#include <PowerUsage.h>
+
+PowerUsage powerUsage;
+
+void setup() {
+	Serial.begin();
+}
+
+void loop() {
+	int powerUsageNow = powerUsage.getPowerUsageMilliWatts();
+	Serial.print("Power usage is ");
+	Serial.print(powerUsageNow);
+	Serial.println(" mW");
+}

--- a/examples/presence.ino
+++ b/examples/presence.ino
@@ -1,0 +1,21 @@
+#include <Arduino.h>
+#include <Presence.h>
+
+const uint8_t profileId = 0; // a profile is a group of users. 0 indicates all users
+const uint8_t roomId = 0; // 0 is a special case indicating the entire sphere
+
+Presence presence;
+
+void setup() {
+	Serial.begin();
+}
+
+void loop() {
+	bool isInRoom = presence.isPresent(profileId, roomId);
+	if (isInRoom) {
+		Serial.println("Profile is in sphere");
+	}
+	else {
+		Serial.println("Profile is not in sphere");
+	}
+}

--- a/include/PowerUsage.h
+++ b/include/PowerUsage.h
@@ -2,7 +2,7 @@
 
 #include <microapp.h>
 
-class PowerUsage{
+class PowerUsage {
 public:
 	// Empty constructor
 	PowerUsage(){};

--- a/include/PowerUsage.h
+++ b/include/PowerUsage.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <microapp.h>
+
+class PowerUsage{
+public:
+	// Empty constructor
+	PowerUsage(){};
+
+	/**
+	 * Request the filtered power usage in milliwatts from bluenet
+	 *
+	 * @return uint32_t Filtered power usage in milliwatts
+	 */
+	int32_t getPowerUsageMilliWatts();
+};

--- a/include/Presence.h
+++ b/include/Presence.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <microapp.h>
+
+const uint8_t MAX_ROOMS = 64;
+
+class Presence {
+private:
+	/**
+	 * Request the presence bitmask of a profile from bluenet
+	 *
+	 * @param profileId   The id of the profile for which to request presence
+	 * @return bitmask    A 64-bit bitmask for a single profile. If the Nth bit is set,
+	 *                    the profile is present in the Nth room. Bit 0 represents the sphere
+	 */
+	uint64_t getPresence(uint8_t profileId);
+
+public:
+	// Empty constructor
+	Presence(){};
+
+	/**
+	 * Check if a profile is present in a room or in the sphere
+	 *
+	 * @param profileId Id of the profile. Use 0 for all users
+	 * @param roomId    Id of the room. When 0, check for the whole sphere
+	 * @return          True if profile present in the room, false if not
+	 */
+	bool isPresent(uint8_t profileId, uint8_t roomId);
+};

--- a/src/CrownstoneRelay.cpp
+++ b/src/CrownstoneRelay.cpp
@@ -1,5 +1,4 @@
 #include <CrownstoneRelay.h>
-#include <Serial.h>
 
 void CrownstoneRelay::switchOff() {
 	setSwitch(CS_MICROAPP_SDK_SWITCH_OFF);

--- a/src/PowerUsage.cpp
+++ b/src/PowerUsage.cpp
@@ -1,0 +1,14 @@
+#include <PowerUsage.h>
+
+int32_t PowerUsage::getPowerUsageMilliWatts() {
+	uint8_t* out = getOutgoingMessagePayload();
+	microapp_sdk_power_usage_t* powerRequest = reinterpret_cast<microapp_sdk_power_usage_t*>(out);
+	powerRequest->header.messageType = CS_MICROAPP_SDK_TYPE_POWER_USAGE;
+	powerRequest->header.ack = CS_MICROAPP_SDK_ACK_REQUEST;
+	powerRequest->type = CS_MICROAPP_SDK_POWER_USAGE_POWER;
+	sendMessage();
+	if (powerRequest->header.ack != CS_MICROAPP_SDK_ACK_SUCCESS) {
+		return -1;
+	}
+	return powerRequest->powerUsage;
+}

--- a/src/PowerUsage.cpp
+++ b/src/PowerUsage.cpp
@@ -1,11 +1,11 @@
 #include <PowerUsage.h>
 
 int32_t PowerUsage::getPowerUsageMilliWatts() {
-	uint8_t* out = getOutgoingMessagePayload();
+	uint8_t* out                             = getOutgoingMessagePayload();
 	microapp_sdk_power_usage_t* powerRequest = reinterpret_cast<microapp_sdk_power_usage_t*>(out);
-	powerRequest->header.messageType = CS_MICROAPP_SDK_TYPE_POWER_USAGE;
-	powerRequest->header.ack = CS_MICROAPP_SDK_ACK_REQUEST;
-	powerRequest->type = CS_MICROAPP_SDK_POWER_USAGE_POWER;
+	powerRequest->header.messageType         = CS_MICROAPP_SDK_TYPE_POWER_USAGE;
+	powerRequest->header.ack                 = CS_MICROAPP_SDK_ACK_REQUEST;
+	powerRequest->type                       = CS_MICROAPP_SDK_POWER_USAGE_POWER;
 	sendMessage();
 	if (powerRequest->header.ack != CS_MICROAPP_SDK_ACK_SUCCESS) {
 		return -1;

--- a/src/Presence.cpp
+++ b/src/Presence.cpp
@@ -1,0 +1,23 @@
+#include <Presence.h>
+
+uint64_t Presence::getPresence(uint8_t profileId) {
+	uint8_t* out = getOutgoingMessagePayload();
+	microapp_sdk_presence_t* presenceRequest = reinterpret_cast<microapp_sdk_presence_t*>(out);
+	presenceRequest->header.messageType = CS_MICROAPP_SDK_TYPE_PRESENCE;
+	presenceRequest->header.ack = CS_MICROAPP_SDK_ACK_REQUEST;
+	presenceRequest->profileId = profileId;
+	presenceRequest->presenceBitmask = 0;
+	sendMessage();
+	if (presenceRequest->header.ack != CS_MICROAPP_SDK_ACK_SUCCESS) {
+		return 0;
+	}
+	return presenceRequest->presenceBitmask;
+}
+
+bool Presence::isPresent(uint8_t profileId, uint8_t roomId) {
+	if (roomId >= MAX_ROOMS) {
+		return false;
+	}
+	uint64_t presenceBitmask = getPresence(profileId);
+	return presenceBitmask & (1 << roomId);
+}

--- a/src/Presence.cpp
+++ b/src/Presence.cpp
@@ -1,12 +1,12 @@
 #include <Presence.h>
 
 uint64_t Presence::getPresence(uint8_t profileId) {
-	uint8_t* out = getOutgoingMessagePayload();
+	uint8_t* out                             = getOutgoingMessagePayload();
 	microapp_sdk_presence_t* presenceRequest = reinterpret_cast<microapp_sdk_presence_t*>(out);
-	presenceRequest->header.messageType = CS_MICROAPP_SDK_TYPE_PRESENCE;
-	presenceRequest->header.ack = CS_MICROAPP_SDK_ACK_REQUEST;
-	presenceRequest->profileId = profileId;
-	presenceRequest->presenceBitmask = 0;
+	presenceRequest->header.messageType      = CS_MICROAPP_SDK_TYPE_PRESENCE;
+	presenceRequest->header.ack              = CS_MICROAPP_SDK_ACK_REQUEST;
+	presenceRequest->profileId               = profileId;
+	presenceRequest->presenceBitmask         = 0;
 	sendMessage();
 	if (presenceRequest->header.ack != CS_MICROAPP_SDK_ACK_SUCCESS) {
 		return 0;


### PR DESCRIPTION
Described in issue #18 

I reused a lot of the code from https://github.com/crownstone/crownstone-microapp/pull/8, so credit also to @mPlagge for much of the code. That PR was closed but IMO not completely justified, since the presence and powerusage api did actually add something. I basically updated it to work with the refactored sdk protocol.

Tested and works on a dev board, although a dev board does not actually measure power of course.

Should be a simple merge.