### PR TITLE
Calls contructors before main

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -41,16 +41,19 @@ TARGET=$(BUILD_PATH)/$(TARGET_NAME)
 # Number of pages
 MICROAPP_PAGES=2
 
-# For c++
-# I have removed nanolib as well. Now I have to check if for e.g. memset I
-# have to provide a function call to the memset of Crownstone.
+# These flags are meant for C++
+# The nano newlib library is removed as well. This reduces binary size even more. Only disadvantage is that memset, etc
+# need to be implemented. To enable newlib nano again: `--specs=nano.specs -Wl,-lc_nano`
 FLAGS=-std=c++17 -mthumb -ffunction-sections -fdata-sections -Wall -Werror \
 	  -fno-strict-aliasing -fno-builtin -fshort-enums -Wno-error=format \
 	  -fno-exceptions -fdelete-dead-exceptions -fno-unwind-tables -fno-non-call-exceptions \
-	  -nostdlib -fno-threadsafe-statics \
-	  -Wl,--gc-sections -Wl,-eReset_Handler \
+	  -fno-threadsafe-statics \
+	  -nostdlib \
+	  -Wl,--gc-sections \
+	  -Wl,-eReset_Handler \
 	  -g \
-	  -Wno-error=unused-function -Os -fomit-frame-pointer -Wl,-z,nocopyreloc --specs=nano.specs \
+	  -Wno-error=unused-function -Os -fomit-frame-pointer -Wl,-z,nocopyreloc \
+	  --specs=nosys.specs -Wl,-lnosys \
 	  -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -u _printf_float
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #

--- a/src/main.c
+++ b/src/main.c
@@ -63,10 +63,34 @@ int main() {
 	return -1;
 }
 
+// provided by the linker
+extern void (*__preinit_array_start []) (void) __attribute__((weak));
+extern void (*__preinit_array_end []) (void) __attribute__((weak));
+extern void (*__init_array_start []) (void) __attribute__((weak));
+extern void (*__init_array_end []) (void) __attribute__((weak));
+
+void __libc_init_array (void)
+{
+  size_t count;
+  size_t i;
+
+  count = __preinit_array_end - __preinit_array_start;
+  for (i = 0; i < count; i++)
+    __preinit_array_start[i] ();
+
+  // normally here a call to custom _init() function
+
+  count = __init_array_end - __init_array_start;
+  for (i = 0; i < count; i++)
+    __init_array_start[i] ();
+}
+
+
 /*
  * We will enter from the Reset_Handler. This is the very first instruction as defined in the assembly file startup.S.
  */
 __attribute__((weak)) void _start(void) {
+	__libc_init_array();
 	main();
 }
 


### PR DESCRIPTION
Implements `__libc_init_array`. Later on we might try to find out why this isn't done. For now this calls all constructors manually in main.c before main() is called.

This fixes issues with globally defined constructors.